### PR TITLE
Exclude KDSoapServerObjectInterface.cpp from moc

### DIFF
--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
 	KDSoapThreadPool.cpp
 )
 
+set_source_files_properties(KDSoapServerObjectInterface.cpp PROPERTIES SKIP_AUTOMOC TRUE)
 add_library(kdsoap-server ${KDSoap_LIBRARY_MODE} ${SOURCES})
 target_link_libraries(kdsoap-server kdsoap ${QT_LIBRARIES})
 set_target_properties(kdsoap-server PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})


### PR DESCRIPTION
CMake seems to detect that KDSoapServerObjectInterface.cpp needs
to have moc run on it, it does not. Set SKIP_AUTOMOC property to
exclude from auto moc, thus removing the following warning:

KDSoapServerObjectInterface.h:0: Note: No relevant classes found.
No output generated.
