### PR TITLE
Fix a warning about unused parameter.

### DIFF
--- a/src/KDSoapServer/KDSoapServerSocket.cpp
+++ b/src/KDSoapServer/KDSoapServerSocket.cpp
@@ -209,7 +209,7 @@ void KDSoapServerSocket::slotReadyRead()
     if (requestType == "GET") {
         if (path == server->wsdlPathInUrl() && handleWsdlDownload()) {
             return;
-        } else if (handleFileDownload(serverObjectInterface, replyMsg, path)) {
+        } else if (handleFileDownload(serverObjectInterface, path)) {
             return;
         }
 
@@ -283,7 +283,7 @@ bool KDSoapServerSocket::handleWsdlDownload()
     return false;
 }
 
-bool KDSoapServerSocket::handleFileDownload(KDSoapServerObjectInterface *serverObjectInterface, KDSoapMessage &replyMsg, const QString &path)
+bool KDSoapServerSocket::handleFileDownload(KDSoapServerObjectInterface *serverObjectInterface, const QString &path)
 {
     QByteArray contentType;
     QIODevice* device = serverObjectInterface->processFileRequest(path, contentType);

--- a/src/KDSoapServer/KDSoapServerSocket_p.h
+++ b/src/KDSoapServer/KDSoapServerSocket_p.h
@@ -63,7 +63,7 @@ private Q_SLOTS:
 
 private:
     bool handleWsdlDownload();
-    bool handleFileDownload(KDSoapServerObjectInterface* serverObjectInterface, KDSoapMessage& replyMsg, const QString& path);
+    bool handleFileDownload(KDSoapServerObjectInterface* serverObjectInterface, const QString& path);
     void makeCall(KDSoapServerObjectInterface* serverObjectInterface,
                   const KDSoapMessage& requestMsg, KDSoapMessage& replyMsg,
                   const KDSoapHeaders& requestHeaders,


### PR DESCRIPTION
Since we are sending HTTP errors on file download errors we no more
need SOAP reply message there.
