### PR TITLE
noop log calls if LogLevel is LogNothing

### DIFF
--- a/src/KDSoapServer/KDSoapServer.cpp
+++ b/src/KDSoapServer/KDSoapServer.cpp
@@ -199,6 +199,9 @@ QString KDSoapServer::logFileName() const
 
 void KDSoapServer::log(const QByteArray &text)
 {
+    if (d->m_logLevel == KDSoapServer::LogNothing)
+        return;
+
     QMutexLocker lock(&d->m_logMutex);
     if (!d->m_logFile.isOpen() && !d->m_logFileName.isEmpty()) {
         d->m_logFile.setFileName(d->m_logFileName);
@@ -213,12 +216,14 @@ void KDSoapServer::log(const QByteArray &text)
 
 void KDSoapServer::flushLogFile()
 {
-    d->m_logFile.flush();
+    if (d->m_logFile.isOpen())
+        d->m_logFile.flush();
 }
 
 void KDSoapServer::closeLogFile()
 {
-    d->m_logFile.close();
+    if (d->m_logFile.isOpen())
+        d->m_logFile.close();
 }
 
 bool KDSoapServer::setExpectedSocketCount(int sockets)


### PR DESCRIPTION
I've only experienced this on qt5 builds, but for some reason with
the default log level of LogNothing, calls to KDSoapServer::log
result in continuous warning about the QIODevice not being open
for writing

For completeness I've added some checks for flushing and closing the log file as well
