### PR TITLE
add the possibility to handle custom HTTP requests

### DIFF
--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
   KDSoapServerThread.cpp
   KDSoapServerAuthInterface.cpp
   KDSoapServerRawXMLInterface.cpp
+  KDSoapServerCustomVerbRequestInterface.cpp
   KDSoapSocketList.cpp
   KDSoapThreadPool.cpp
 )
@@ -42,6 +43,7 @@ if(KDSoap_IS_ROOT_PROJECT)
       KDSoapServerObjectInterface
       KDSoapServerAuthInterface
       KDSoapServerRawXMLInterface
+      KDSoapServerCustomVerbRequestInterface
     COMMON_HEADER
       KDSoapServer
   )
@@ -54,6 +56,7 @@ if(KDSoap_IS_ROOT_PROJECT)
     KDSoapServer.h
     KDSoapServerAuthInterface.h
     KDSoapServerRawXMLInterface.h
+    KDSoapServerCustomVerbRequestInterface.h
     KDSoapDelayedResponseHandle.h
     KDSoapServerObjectInterface.h
     KDSoapServerGlobal.h

--- a/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.cpp
@@ -1,0 +1,46 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "KDSoapServerCustomVerbRequestInterface.h"
+
+KDSoapServerCustomVerbRequestInterface::KDSoapServerCustomVerbRequestInterface()
+    : d(0)
+{
+
+}
+
+KDSoapServerCustomVerbRequestInterface::~KDSoapServerCustomVerbRequestInterface()
+{
+
+}
+
+bool KDSoapServerCustomVerbRequestInterface::processCustomVerbRequest(const QByteArray &requestType, const QByteArray &requestData,
+                                                                      const QMap<QByteArray, QByteArray> &httpHeaders, QByteArray &customAnswer)
+{
+    Q_UNUSED(requestType);
+    Q_UNUSED(requestData);
+    Q_UNUSED(httpHeaders);
+    Q_UNUSED(customAnswer);
+
+    return false;
+}

--- a/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.h
+++ b/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+#ifndef KDSOAPSERVERCUSTOMVERBREQUESTINTERFACE_H
+#define KDSOAPSERVERCUSTOMVERBREQUESTINTERFACE_H
+
+#include "KDSoapServerGlobal.h"
+#include <QtCore/QObject>
+class KDSoapAuthentication;
+class KDSoapServerSocket;
+
+/**
+ * Additional interface for handling custom verb request.
+ *
+ * In addition to deriving from KDSoapServerObjectInterface, you can derive from
+ * KDSoapServerCustomVerbRequestInterface in order to handle custom verb HTML requests.
+ *
+ * Use Q_INTERFACES(KDSoapServerCustomVerbRequestInterface) in your derived class (under Q_OBJECT)
+ * so that Qt can discover the additional inheritance.
+ *
+ * \since 1.5
+ */
+class KDSOAPSERVER_EXPORT KDSoapServerCustomVerbRequestInterface
+{
+public:
+    /**
+     * Constructor
+     */
+    KDSoapServerCustomVerbRequestInterface();
+
+    /**
+     * Destructor
+     */
+    virtual ~KDSoapServerCustomVerbRequestInterface();
+
+    /**
+     * Process a request made with a custom HTTP verb
+     * @param requestType HTTP verb other than GET and POST
+     * @param requestData is the content of the request
+     * @param httpHeaders the map of http headers (keys have been lowercased since they are case insensitive)
+     * @param customAnswer allow to send back the answer to the client if the request has been handled
+     * @return true if the request has been handled and if customAnswer is valid and will be sent back to the client.
+     */
+    virtual bool processCustomVerbRequest(const QByteArray &requestType, const QByteArray &requestData,
+                                          const QMap<QByteArray, QByteArray> &httpHeaders, QByteArray &customAnswer);
+
+private:
+    friend class KDSoapServerSocket;
+    class Private;
+    Private* const d;
+};
+
+QT_BEGIN_NAMESPACE
+Q_DECLARE_INTERFACE(KDSoapServerCustomVerbRequestInterface,
+                    "com.kdab.KDSoap.ServerCustomVerbRequestInterface/1.0")
+QT_END_NAMESPACE
+
+#endif /* KDSOAPSERVERCUSTOMVERBREQUESTINTERFACE_H */


### PR DESCRIPTION
modify KDSoapServerObjectInterface to add a new method to handle custom requests
modify KDSoapServerSocket to not reply when custom requests are handled

I am developping a library based on Qt5 and KDSoap to handle UPnP (https://gitlab.com/homeautomationqt/upnp-player-qt). In order to handle http and soap I am using KDSoap server and client implementations.