### PR TITLE
WS Addressing Support

### DIFF
--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
   KDSoapSslHandler.cpp
   KDSoapReplySslHandler.cpp
   KDSoapFaultException.cpp
+  KDSoapMessageAddressingProperties.cpp
+  KDSoapEndpointReference.cpp
 )
 
 add_library(kdsoap ${KDSoap_LIBRARY_MODE} ${SOURCES})
@@ -49,6 +51,8 @@ if(KDSoap_IS_ROOT_PROJECT)
       KDSoapValue,KDSoapValueList
       KDSoapPendingCallWatcher
       KDSoapFaultException
+      KDSoapMessageAddressingProperties
+      KDSoapEndpointReference
       KDSoapPendingCall
       KDSoapAuthentication
     COMMON_HEADER
@@ -70,6 +74,8 @@ if(KDSoap_IS_ROOT_PROJECT)
     KDSoap.h
     KDSoapSslHandler.h
     KDSoapFaultException.h
+    KDSoapMessageAddressingProperties.h
+    KDSoapEndpointReference.h
     DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient
   )
 

--- a/src/KDSoapClient/KDSoapClient.pro
+++ b/src/KDSoapClient/KDSoapClient.pro
@@ -23,7 +23,9 @@ INSTALLHEADERS = KDSoapMessage.h \
     KDSoapNamespaceManager.h \
     KDSoapSslHandler.h \
     KDDateTime.h \
-    KDSoapFaultException.h
+    KDSoapFaultException.h \
+    KDSoapMessageAddressingProperties.cpp \
+    KDSoapEndpointReference.cpp
 PRIVATEHEADERS = KDSoapPendingCall_p.h \
     KDSoapPendingCallWatcher_p.h \
     KDSoapClientInterface_p.h \
@@ -51,7 +53,9 @@ SOURCES = KDSoapMessage.cpp \
     KDSoapJob.cpp \
     KDSoapSslHandler.cpp \
     KDSoapReplySslHandler.cpp \
-    KDSoapFaultException.cpp
+    KDSoapFaultException.cpp \
+    KDSoapMessageAddressingProperties.cpp \
+    KDSoapEndpointReference.cpp
 DEFINES += KDSOAP_BUILD_KDSOAP_LIB
 
 # installation targets:

--- a/src/KDSoapClient/KDSoapEndpointReference.cpp
+++ b/src/KDSoapClient/KDSoapEndpointReference.cpp
@@ -1,0 +1,79 @@
+#include "KDSoapEndpointReference.h"
+
+#include <QDebug>
+
+class KDSoapEndpointReferenceData : public QSharedData
+{
+public:
+    QString m_address;
+    KDSoapValue m_referenceParameters;
+    KDSoapValue m_metadata;
+
+//    <wsa:EndpointReference>
+//        <wsa:Address>xs:anyURI</wsa:Address>
+//        <wsa:ReferenceParameters>xs:any*</wsa:ReferenceParameters> ?
+//        <wsa:Metadata>xs:any*</wsa:Metadata>?
+//    </wsa:EndpointReference>
+    KDSoapEndpointReferenceData() {}
+};
+
+KDSoapEndpointReference::KDSoapEndpointReference()
+    : d(new KDSoapEndpointReferenceData)
+{
+}
+
+KDSoapEndpointReference::KDSoapEndpointReference(const QString &address)
+    : d(new KDSoapEndpointReferenceData)
+{
+    d->m_address = address;
+}
+
+KDSoapEndpointReference::KDSoapEndpointReference(const KDSoapEndpointReference &other)
+    : d(other.d)
+{
+}
+
+KDSoapEndpointReference &KDSoapEndpointReference::operator =(const KDSoapEndpointReference &other)
+{
+    d = other.d;
+    return *this;
+}
+
+KDSoapEndpointReference::~KDSoapEndpointReference()
+{
+}
+
+QString KDSoapEndpointReference::address() const
+{
+    return d->m_address;
+}
+
+void KDSoapEndpointReference::setAddress(const QString &address)
+{
+    d->m_address = address;
+}
+KDSoapValue KDSoapEndpointReference::metadata() const
+{
+    return d->m_metadata;
+}
+
+void KDSoapEndpointReference::setMetadata(const KDSoapValue &metadata)
+{
+    d->m_metadata = metadata;
+}
+
+bool KDSoapEndpointReference::isEmpty() const
+{
+    return d->m_address.isEmpty();
+}
+
+KDSoapValue KDSoapEndpointReference::referenceParameters() const
+{
+    return d->m_referenceParameters;
+}
+
+void KDSoapEndpointReference::setReferenceParameters(const KDSoapValue &referenceParameters)
+{
+    d->m_referenceParameters = referenceParameters;
+}
+

--- a/src/KDSoapClient/KDSoapEndpointReference.h
+++ b/src/KDSoapClient/KDSoapEndpointReference.h
@@ -1,0 +1,109 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#ifndef KDSOAPENDPOINTREFERENCE_H
+#define KDSOAPENDPOINTREFERENCE_H
+
+#include "KDSoapGlobal.h"
+#include "KDSoapValue.h"
+#include <QString>
+#include <QSharedDataPointer>
+
+class KDSoapEndpointReferenceData;
+/**
+ * KDSoapEndpointReference is the abstraction class to hold
+ * an Endpoint Reference properties.
+ *
+ * \see: http://www.w3.org/TR/ws-addr-core/#eprinfoset
+ * \since 1.5
+ */
+class KDSOAP_EXPORT KDSoapEndpointReference
+{
+  public:
+
+    /**
+     * Construct an default KDSoapEndpointReference object
+     */
+    KDSoapEndpointReference();
+
+    /**
+     * Construct a KDSoapEndpointReference object with the given \p address
+     */
+    KDSoapEndpointReference(const QString &address);
+
+    /**
+     * Copy constructor of KDSoapEndpointReference
+     */
+    KDSoapEndpointReference(const KDSoapEndpointReference &other);
+
+    /**
+     * Copy the content of the KDSoapEndpointReference from \p other to the object
+     */
+    KDSoapEndpointReference &operator =(const KDSoapEndpointReference &other);
+
+    /**
+      * Destroy the object and frees up any resource used.
+      */
+    ~KDSoapEndpointReference();
+
+    /**
+     * Returns the address
+     */
+    QString address() const;
+
+    /**
+     * Sets the address of the endpoint reference
+     * @param address
+     */
+    void setAddress(const QString &address);
+
+    /**
+     * Return the reference parameters, which can be of any type
+     * so we return a KDSoapValue.
+     */
+    KDSoapValue referenceParameters() const;
+
+    /**
+     * Sets the reference parameters
+     */
+    void setReferenceParameters(const KDSoapValue &referenceParameters);
+
+    /**
+     * Return the meta data, which can be of any type
+     * so we return a KDSoapValue
+     */
+    KDSoapValue metadata() const;
+
+    /**
+     * Sets the meta data
+     */
+    void setMetadata(const KDSoapValue &metadata);
+
+    bool isEmpty() const;
+
+private:
+    QSharedDataPointer<KDSoapEndpointReferenceData> d;
+};
+
+#endif // KDSOAPENDPOINTREFERENCE_H
+

--- a/src/KDSoapClient/KDSoapMessage.cpp
+++ b/src/KDSoapClient/KDSoapMessage.cpp
@@ -32,11 +32,13 @@ class KDSoapMessageData : public QSharedData
 {
 public:
     KDSoapMessageData()
-        : use(KDSoapMessage::LiteralUse), isFault(false)
+        : use(KDSoapMessage::LiteralUse), isFault(false), hasMessageAddressingProperties(false)
     {}
 
     KDSoapMessage::Use use;
     bool isFault;
+    bool hasMessageAddressingProperties;
+    KDSoapMessageAddressingProperties messageAddressingProperties;
 };
 
 KDSoapMessage::KDSoapMessage()
@@ -131,6 +133,22 @@ QString KDSoapMessage::faultAsString() const
 void KDSoapMessage::setFault(bool fault)
 {
     d->isFault = fault;
+}
+
+KDSoapMessageAddressingProperties KDSoapMessage::messageAddressingProperties() const
+{
+    return d->messageAddressingProperties;
+}
+
+void KDSoapMessage::setMessageAddressingProperties(const KDSoapMessageAddressingProperties &map)
+{
+    d->messageAddressingProperties = map;
+    d->hasMessageAddressingProperties = true;
+}
+
+bool KDSoapMessage::hasMessageAddressingProperties() const
+{
+    return d->hasMessageAddressingProperties;
 }
 
 KDSoapMessage::Use KDSoapMessage::use() const

--- a/src/KDSoapClient/KDSoapMessage.h
+++ b/src/KDSoapClient/KDSoapMessage.h
@@ -25,7 +25,10 @@
 
 #include <QtCore/QSharedDataPointer>
 #include <QtCore/QVariant>
+
 #include "KDSoapValue.h"
+#include "KDSoapMessageAddressingProperties.h"
+
 QT_BEGIN_NAMESPACE
 class QString;
 QT_END_NAMESPACE
@@ -148,6 +151,19 @@ public:
      */
     void setFault(bool fault);
 
+    /**
+     * Attach to a KDSoapMessage the message addressings properties that will be written
+     * in its header, calling this will make hasMessageAddressingProperties() return true.
+     */
+    void setMessageAddressingProperties(const KDSoapMessageAddressingProperties &map);
+
+    /**
+     * Return true whether a KDSoapMessageAddressingProperties has been set for this
+     * KDSoapMessage
+     */
+    bool hasMessageAddressingProperties() const;
+
+    KDSoapMessageAddressingProperties messageAddressingProperties() const;
 private:
     bool isNull() const;
     friend class KDSoapPendingCall;

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -1,0 +1,269 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+#include "KDSoapMessageAddressingProperties.h"
+
+#include "KDSoapNamespacePrefixes_p.h"
+#include "KDSoapNamespaceManager.h"
+
+#include <QDebug>
+#include <QLatin1String>
+#include <QPair>
+#include <QString>
+#include <QXmlStreamWriter>
+
+class KDSoapMessageAddressingPropertiesData : public QSharedData
+{
+public:
+    KDSoapMessageAddressingPropertiesData(){}
+
+    QString destination;    // Provides the address of the intended receiver of this message
+    QString action;         // Identifies the semantics implied by this message
+    KDSoapEndpointReference sourceEndpoint; // Message origin, could be included to facilitate longer running message exchanges.
+    KDSoapEndpointReference replyEndpoint;  // Intended receiver for replies to this message, could be included to facilitate longer running message exchanges.
+    KDSoapEndpointReference faultEndpoint;  // Intended receiver for faults related to this message, could be included to facilitate longer running message exchanges.
+    QString messageID;      // Unique identifier for this message, may be included to facilitate longer running message exchanges.
+    Relationship relationship;   // Indicates relationship to a prior message, could be included to facilitate longer running message exchanges.
+    KDSoapValue referenceParameters; // Equivalent of the reference parameters object from the endpoint reference within WSDL file
+};
+
+KDSoapMessageAddressingProperties::KDSoapMessageAddressingProperties()
+    : d(new KDSoapMessageAddressingPropertiesData)
+{
+}
+
+KDSoapMessageAddressingProperties::KDSoapMessageAddressingProperties(const KDSoapMessageAddressingProperties &other)
+    : d(other.d)
+{
+}
+
+KDSoapMessageAddressingProperties &KDSoapMessageAddressingProperties::operator =(const KDSoapMessageAddressingProperties &other)
+{
+    d = other.d;
+    return *this;
+}
+
+QString KDSoapMessageAddressingProperties::destination() const
+{
+    return d->destination;
+}
+
+void KDSoapMessageAddressingProperties::setDestination(const QString &destination)
+{
+    d->destination = destination;
+}
+
+QString KDSoapMessageAddressingProperties::action() const
+{
+    return d->action;
+}
+
+void KDSoapMessageAddressingProperties::setAction(const QString &action)
+{
+    d->action = action;
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::sourceEndpoint() const
+{
+    return d->sourceEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::sourceEndpointAddress() const
+{
+    return d->sourceEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setSourceEndpoint(const KDSoapEndpointReference &sourceEndpoint)
+{
+    d->sourceEndpoint = sourceEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setSourceEndpointAddress(const QString &sourceEndpoint)
+{
+    d->sourceEndpoint.setAddress(sourceEndpoint);
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::replyEndpoint() const
+{
+    return d->replyEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::replyEndpointAddress() const
+{
+    return d->replyEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setReplyEndpoint(const KDSoapEndpointReference &replyEndpoint)
+{
+    d->replyEndpoint = replyEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setReplyEndpointAddress(const QString &replyEndpoint)
+{
+    d->replyEndpoint.setAddress(replyEndpoint);
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::faultEndpoint() const
+{
+    return d->faultEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::faultEndpointAddress() const
+{
+    return d->faultEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setFaultEndpoint(const KDSoapEndpointReference &faultEndpoint)
+{
+    d->faultEndpoint = faultEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setFaultEndpointAddress(const QString &faultEndpoint)
+{
+    d->faultEndpoint.setAddress(faultEndpoint);
+}
+
+QString KDSoapMessageAddressingProperties::messageID() const
+{
+    return d->messageID;
+}
+
+void KDSoapMessageAddressingProperties::setMessageID(const QString &id)
+{
+    d->messageID = id;
+}
+
+Relationship KDSoapMessageAddressingProperties::relationship() const
+{
+    return d->relationship;
+}
+
+void KDSoapMessageAddressingProperties::setRelationship(const Relationship relationship)
+{
+    d->relationship = relationship;
+}
+
+KDSoapValue KDSoapMessageAddressingProperties::referenceParameters() const
+{
+    return d->referenceParameters;
+}
+
+void KDSoapMessageAddressingProperties::setReferenceParameters(const KDSoapValue &rp)
+{
+    d->referenceParameters = rp;
+}
+
+KDSoapMessageAddressingProperties::~KDSoapMessageAddressingProperties()
+{
+}
+
+QString KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::KDSoapAddressingPredefinedAddress address)
+{
+    switch (address) {
+        case Anonymous:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/anonymous");
+            break;
+        case None:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/none");
+            break;
+        case Reply:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/reply");
+            break;
+        case Unspecified:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/unspecified");
+            break;
+        default:
+            Q_ASSERT(false); // should never happen
+            return QLatin1String("");
+            break;
+    }
+}
+
+static void writeAddressField(QXmlStreamWriter &writer, const QString& address)
+{
+    writer.writeStartElement(KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("Address"));
+    writer.writeCharacters(address);
+    writer.writeEndElement();
+}
+
+void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, KDSoapValue::Use use, const QString &messageNamespace, bool forceQualified) const
+{
+    if (d->destination == predefinedAddressToString(None) || d->destination.isEmpty() )
+        return; // we discard the message
+
+    if (d->action.isEmpty())
+        return;
+
+    const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
+
+    writer.writeStartElement(addressingNS, QLatin1String("To"));
+    writer.writeCharacters(d->destination);
+    writer.writeEndElement();
+
+    writer.writeStartElement(addressingNS, QLatin1String("From"));
+    writeAddressField(writer, d->sourceEndpoint.address());
+    writer.writeEndElement();
+
+    if (!d->replyEndpoint.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("ReplyTo"));
+        writeAddressField(writer, d->replyEndpoint.address());
+        writer.writeEndElement();
+    }
+
+    if (!d->faultEndpoint.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("FaultTo"));
+        writeAddressField(writer, d->faultEndpoint.address());
+        writer.writeEndElement();
+    }
+
+    if (!d->action.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("Action"));
+        writer.writeCharacters(d->action);
+        writer.writeEndElement();
+    }
+
+    if (!d->messageID.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("MessageID"));
+        writer.writeCharacters(d->messageID);
+        writer.writeEndElement();
+    }
+
+    if (!d->relationship.first.isEmpty() || !d->relationship.second.isEmpty() ) {
+        writer.writeStartElement(addressingNS, QLatin1String("RelatesTo"));
+        // TODO: support RelatedTo serilization
+        writer.writeEndElement();
+    }
+
+    if (!d->referenceParameters.isNull()) {
+        writer.writeStartElement(addressingNS, QLatin1String("ReferenceParameters"));
+        // TODO: support referenceParameters serilization
+        writer.writeEndElement();
+    }
+}
+
+QDebug operator <<(QDebug dbg, const KDSoapMessageAddressingProperties &msg)
+{
+    dbg << msg.action() << msg.destination() << msg.sourceEndpoint().address() << msg.replyEndpoint().address() << msg.faultEndpoint().address() << msg.messageID();
+
+    return dbg;
+}
+

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.h
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.h
@@ -1,0 +1,232 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+#ifndef KDSOAPMESSAGEADDRESSINGPROPERTIES_H
+#define KDSOAPMESSAGEADDRESSINGPROPERTIES_H
+
+#include <QtCore/QSharedDataPointer>
+#include "KDSoapGlobal.h"
+#include <QPair>
+
+#include "KDSoapEndpointReference.h"
+#include "KDSoapValue.h"
+
+QT_BEGIN_NAMESPACE
+class QString;
+QT_END_NAMESPACE
+
+class KDSoapNamespacePrefixes;
+class KDSoapMessageAddressingPropertiesData;
+
+typedef QPair<QString, QString> Relationship;
+
+/**
+ * The KDSoapMessageAddressingProperties class is the abstraction of the
+ * WS-Addressing specification. This specification set up information within
+ * soap envelope header. This class is meant to be filled with the data you want
+ * to have in the soap header and associate to a given message using
+ * \see KDSoapMessage::setMessageAddressingProperties
+ *
+ * Important: This class does not ensure any kind of validation to the data being passed to it
+ * \since 1.5
+ */
+
+class KDSOAP_EXPORT KDSoapMessageAddressingProperties
+{
+public:
+
+    /**
+     * This enum contains all the predefined addresses used within
+     * ws addressing specification, it is meant to be used with predefinedAddress
+     * helper function to retrieve the uri as a QString
+     * \see predefinedAddressToString
+     */
+    enum KDSoapAddressingPredefinedAddress {
+        None,
+        Anonymous,
+        Reply,
+        Unspecified
+    };
+
+    /**
+     * Constructs an empty KDSoapMessageAddressingProperties object.
+     */
+    KDSoapMessageAddressingProperties();
+
+    /**
+     * Destructs the KDSoapMessageAddressingProperties object.
+     */
+    ~KDSoapMessageAddressingProperties();
+
+    /**
+     * Constructs a copy of the KDSoapMessageAddressingProperties object given by \p other.
+     */
+    KDSoapMessageAddressingProperties(const KDSoapMessageAddressingProperties &other);
+
+    /**
+     * Copies the contents of the object given by \p other.
+     */
+    KDSoapMessageAddressingProperties &operator =(const KDSoapMessageAddressingProperties &other);
+
+    /**
+     * Returns the destination address, it should match the EndpointReference given from WSDL
+     */
+    QString destination() const;
+
+    /**
+     * Sets the destination address, where the message will be sent to
+     */
+    void setDestination(const QString &destination);
+
+    /**
+     * Returns the action uri, which is the semantic of the message
+     */
+    QString action() const;
+
+    /**
+     * Sets the targeted action of the soap message
+     */
+    void setAction(const QString& action);
+
+    /**
+     * Returns the message sender endpoint
+     * \see KDSoapEndpointReference
+     */
+    KDSoapEndpointReference sourceEndpoint() const;
+
+    /**
+     * Convenient method, returns directly the source endpoint address
+     * \see KDSoapAddressingPredefinedAddress enum
+     */
+    QString sourceEndpointAddress() const;
+
+    /**
+     * Sets the message sender endpoint
+     * \see KDSoapEndpointReference
+     */
+    void setSourceEndpoint(const KDSoapEndpointReference &sourceEndpoint);
+
+    /**
+     * Convenient method, sets the message sender address
+     */
+    void setSourceEndpointAddress(const QString &sourceEndpoint);
+
+    /**
+     * Returns the reply endpoint
+     * \see KDSoapAddressingPredefinedAddress enum
+     */
+    KDSoapEndpointReference replyEndpoint() const;
+
+    /**
+     * Convenient method, returns the sender endpoint address
+     */
+    QString replyEndpointAddress() const;
+
+    /**
+     * Sets the reply endpoint the server should reply to
+     * \see KDSoapEndpointReference
+     */
+    void setReplyEndpoint(const KDSoapEndpointReference &replyEndpoint);
+
+    /**
+     * Convenient method to set directly the reply endpoint address the server should reply to
+     */
+    void setReplyEndpointAddress(const QString &replyEndpoint);
+
+    /**
+     * Returns the fault endpoint, which contains the address the server should send the potential fault error
+     */
+    KDSoapEndpointReference faultEndpoint() const;
+
+    /**
+     * Convenient method that returns the fault endpoint address, which is the address the server should send the potential fault error
+     */
+    QString faultEndpointAddress() const;
+
+    /**
+     * Set the fault endpoint of the message
+     * \see KDSoapEndpointReference
+     */
+    void setFaultEndpoint(const KDSoapEndpointReference &faultEndpoint);
+
+    /**
+     * Convenient method to set directly the fault endpoint address of the message
+     */
+    void setFaultEndpointAddress(const QString &faultEndpoint);
+
+    /**
+     * Returns the message id
+     */
+    QString messageID() const;
+
+    /**
+     * Set the message id
+     */
+    void setMessageID(const QString & id);
+
+    /**
+     * Returns the QString pair of addresses, it indicates relationship to a prior message to facilitate longer running message exchanges.
+     *
+     * In case of an standalone / independant message, the predefined value to use is http://www.w3.org/2005/08/addressing/unspecified
+     * In case of a reply message, when no value has been set, it is predefined with http://www.w3.org/2005/08/addressing/reply which mean, the second QString
+     * of the QPair is the message ID that the message is replying to.
+     */
+    Relationship relationship() const;
+
+    /**
+     * Set the relationship of the message, eg. an previous messageID, no semantic verification is done here.
+     */
+    void setRelationship(const Relationship relationship);
+
+    /**
+     * Returns the custom reference parameters objects, defined within WSDL file
+     */
+    KDSoapValue referenceParameters() const;
+
+    /**
+     * Set the reference parameter, since this value can be anything custom,  it uses a KDSoapValue
+     */
+    void setReferenceParameters(const KDSoapValue & rp);
+
+    /**
+     * Helper function that take the \p address enum to provide the Qstring equivalent
+     */
+    static QString predefinedAddressToString(KDSoapAddressingPredefinedAddress address);
+
+    /**
+     * Write the properties to the soap header, through the QXmlStreamWriter
+     */
+    void writeMessageAddressingProperties(KDSoapNamespacePrefixes& namespacePrefixes, QXmlStreamWriter& writer, KDSoapValue::Use use, const QString& messageNamespace, bool forceQualified) const;
+
+private:
+    QSharedDataPointer<KDSoapMessageAddressingPropertiesData> d;
+};
+
+
+/**
+ * Support for debugging KDSoapMessage object via qDebug() << msg;
+ */
+KDSOAP_EXPORT QDebug operator <<(QDebug dbg, const KDSoapMessageAddressingProperties &msg);
+
+//Q_DECLARE_METATYPE(KDSoapMessageAddressingProperties)
+
+#endif // KDSOAPMESSAGEADDRESSINGPROPERTIES_H

--- a/src/KDSoapClient/KDSoapMessageWriter.cpp
+++ b/src/KDSoapClient/KDSoapMessageWriter.cpp
@@ -51,7 +51,7 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage& message, const
     writer.writeStartDocument();
 
     KDSoapNamespacePrefixes namespacePrefixes;
-    namespacePrefixes.writeStandardNamespaces(writer, m_version);
+    namespacePrefixes.writeStandardNamespaces(writer, m_version, message.hasMessageAddressingProperties());
 
     QString soapEnvelope;
     QString soapEncoding;
@@ -73,7 +73,7 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage& message, const
         messageNamespace = message.namespaceUri();
     }
 
-    if (!headers.isEmpty() || !persistentHeaders.isEmpty()) {
+    if (!headers.isEmpty() || !persistentHeaders.isEmpty() || message.hasMessageAddressingProperties()) {
         // This writeNamespace line adds the xmlns:n1 to <Envelope>, which looks ugly and unusual (and breaks all unittests)
         // However it's the best solution in case of headers, otherwise we get n1 in the header and n2 in the body,
         // and xsi:type attributes that refer to n1, which isn't defined in the body...
@@ -84,6 +84,9 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage& message, const
         }
         Q_FOREACH(const KDSoapMessage& header, headers) {
             header.writeChildren(namespacePrefixes, writer, header.use(), messageNamespace, true);
+        }
+        if (message.hasMessageAddressingProperties()) {
+            message.messageAddressingProperties().writeMessageAddressingProperties(namespacePrefixes, writer, KDSoapValue::LiteralUse, messageNamespace, true);
         }
         writer.writeEndElement(); // Header
     } else {
@@ -110,7 +113,6 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage& message, const
         message.writeElementContents(namespacePrefixes, writer, message.use(), messageNamespace);
         writer.writeEndElement();
     }
-
     writer.writeEndElement(); // Body
     writer.writeEndElement(); // Envelope
     writer.writeEndDocument();

--- a/src/KDSoapClient/KDSoapNamespaceManager.cpp
+++ b/src/KDSoapClient/KDSoapNamespaceManager.cpp
@@ -65,3 +65,8 @@ QString KDSoapNamespaceManager::soapEncoding200305()
 {
     return QString::fromLatin1("http://www.w3.org/2003/05/soap-encoding");
 }
+
+QString KDSoapNamespaceManager::soapMessageAddressing()
+{
+    return QString::fromLatin1("http://www.w3.org/2005/08/addressing");
+}

--- a/src/KDSoapClient/KDSoapNamespaceManager.h
+++ b/src/KDSoapClient/KDSoapNamespaceManager.h
@@ -40,6 +40,7 @@ public:
     static QString soapEnvelope200305();
     static QString soapEncoding();
     static QString soapEncoding200305();
+    static QString soapMessageAddressing();
 
 private: // TODO instantiate to handle custom namespaces per clientinterface
     KDSoapNamespaceManager();

--- a/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
@@ -25,7 +25,8 @@
 #include "KDSoapNamespaceManager.h"
 
 void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter& writer,
-                                                      KDSoapClientInterface::SoapVersion version)
+                                                      KDSoapClientInterface::SoapVersion version,
+                                                      bool messageAddressingEnabled)
 {
     if (version == KDSoapClientInterface::SOAP1_1) {
         writeNamespace(writer, KDSoapNamespaceManager::soapEnvelope(), QLatin1String("soap"));
@@ -37,6 +38,10 @@ void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter& writer,
 
     writeNamespace(writer, KDSoapNamespaceManager::xmlSchema2001(), QLatin1String("xsd"));
     writeNamespace(writer, KDSoapNamespaceManager::xmlSchemaInstance2001(), QLatin1String("xsi"));
+
+    if (messageAddressingEnabled) {
+        writeNamespace(writer, KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("wsa"));
+    }
 
     // Also insert known variants
     insert(KDSoapNamespaceManager::xmlSchema1999(), QString::fromLatin1("xsd"));

--- a/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
@@ -32,7 +32,8 @@ class KDSoapNamespacePrefixes : public QMap<QString /*ns*/, QString /*prefix*/>
 {
 public:
     void writeStandardNamespaces(QXmlStreamWriter& writer,
-                                 KDSoapClientInterface::SoapVersion version = KDSoapClientInterface::SOAP1_1);
+                                 KDSoapClientInterface::SoapVersion version = KDSoapClientInterface::SOAP1_1,
+                                 bool messageAddressingEnabled = false);
 
     void writeNamespace(QXmlStreamWriter& writer, const QString& ns, const QString& prefix) {
         //qDebug() << "writeNamespace" << ns << prefix;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -63,6 +63,7 @@ add_subdirectory(onvif.org)
 add_subdirectory(onvif_ptz)
 add_subdirectory(encapsecurity)
 add_subdirectory(prefix_wsdl)
+add_subdirectory(ws_addressing_support)
 
 # These need internet access
 add_subdirectory(webcalls)

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -33,6 +33,7 @@ SUBDIRS = \
   onvif_ptz \
   encapsecurity \
   prefix_wsdl \
+  ws_addressing_support \
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl

--- a/unittests/ws_addressing_support/CMakeLists.txt
+++ b/unittests/ws_addressing_support/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(ws_addressing_support)
+
+set(WSDL_FILES wsaddressing.wsdl)
+set(ws_addressing_support_SRCS wsaddressing.cpp )
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${ws_addressing_support_SRCS} )

--- a/unittests/ws_addressing_support/ws_addressing_support.pro
+++ b/unittests/ws_addressing_support/ws_addressing_support.pro
@@ -1,0 +1,12 @@
+# This would apply to all .wsdl files... qmake is too limited for this.
+# KDWSDL_OPTIONS = -service OrteLookup
+
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += network xml
+SOURCES = wsaddressingtest.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = wsaddressing.wsdl # Find one relevant on the internet

--- a/unittests/ws_addressing_support/wsaddressing.wsdl
+++ b/unittests/ws_addressing_support/wsaddressing.wsdl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="HelloService"
+   targetNamespace="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns="http://schemas.xmlsoap.org/wsdl/"
+   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+   xmlns:tns="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns:wsa="http://www.w3.org/2005/08/addressing"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+   <message name="SayHelloRequest">
+      <part name="msg" type="xsd:string"/>
+   </message>
+   <message name="SayHelloResponse">
+      <part name="reply" type="xsd:string"/>
+   </message>
+
+   <portType name="Hello_PortType">
+      <operation name="sayHello">
+         <input message="tns:SayHelloRequest" wsaw:Action="http://localhost:8081/hello"/>
+         <output message="tns:SayHelloResponse" wsaw:Action="http://localhost:8081/hello"/>
+      </operation>
+   </portType>
+
+   <binding name="Hello_Binding" type="tns:Hello_PortType">
+      <wsaw:UsingAddressing wsdl:required="true" /> <!--NEED TO BE TAKEN INTO ACCOUNT -->
+      <soap:binding style="document"
+         transport="http://schemas.xmlsoap.org/soap/http"/>
+      <operation name="sayHello" style="document">
+         <soap:operation soapAction="sayHello"/>
+         <input wsaw:Action="http://localhost:8081/hello">
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </input>
+         <output>
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </output>
+      </operation>
+</binding>
+
+   <service name="Hello_Service">
+      <documentation>WSDL File for HelloService</documentation>
+      <port binding="tns:Hello_Binding" name="Hello_Port">
+         <soap:address location="http://localhost:8081/hello" />
+
+         <wsa:EndpointReference
+             xmlns:example="http://example.com/namespace"
+             xmlns:wsdli="http://www.w3.org/2006/01/wsdl-instance"
+             wsdli:wsdlLocation="http://example.com/location">
+
+             <wsa:Address>http://localhost:8081/hello</wsa:Address>
+             <wsa:Metadata>
+                <wsam:InterfaceName>example:Inventory</wsam:InterfaceName>
+             </wsa:Metadata>
+             <wsa:ReferenceParameters>
+               <example:AccountCode>123456789</example:AccountCode>
+               <example:DiscountId>ABCDEFG</example:DiscountId>
+             </wsa:ReferenceParameters>
+         </wsa:EndpointReference>
+
+      </port>
+   </service>
+</definitions>

--- a/unittests/ws_addressing_support/wsaddressingtest.cpp
+++ b/unittests/ws_addressing_support/wsaddressingtest.cpp
@@ -1,0 +1,140 @@
+/****************************************************************************
+** Copyright (C) 2010-2014 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "httpserver_p.h"
+
+#include <QtTest/QtTest>
+#include <QDebug>
+#include <QObject>
+
+#include "KDSoapClient/KDSoapMessageWriter_p.h"
+#include "KDSoapClient/KDSoapMessageAddressingProperties.h"
+#include "KDSoapNamespaceManager.h"
+#include "wsdl_wsaddressing.h"
+
+using namespace KDSoapUnitTestHelpers;
+
+class WSAddressingTest : public QObject
+{
+    Q_OBJECT
+
+public:
+    WSAddressingTest(){}
+    virtual ~WSAddressingTest() {}
+
+private Q_SLOTS:
+    void shouldWriteAProperSoapMessageWithRightsAddressingProperties()
+    {
+        // GIVEN
+        HttpServerThread server(emptyResponse(), HttpServerThread::Public);
+        KDSoapClientInterface client(server.endPoint(), "http://www.ecerami.com/wsdl/HelloService");
+
+        KDSoapMessage message;
+        KDSoapMessageAddressingProperties map;
+
+        QString none = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::None);
+        QCOMPARE(none, QString("http://www.w3.org/2005/08/addressing/none"));
+
+        QString anonymous = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous);
+        QCOMPARE(anonymous, QString("http://www.w3.org/2005/08/addressing/anonymous"));
+
+        // with some message addressing properties
+        map.setAction("sayHello");
+        map.setDestination("http://www.ecerami.com/wsdl/HelloService");
+        map.setSourceEndpointAddress("http://www.ecerami.com/wsdl/source");
+        map.setFaultEndpoint(KDSoapEndpointReference("http://www.ecerami.com/wsdl/fault"));
+        map.setMessageID("uuid:e197db59-0982-4c9c-9702-4234d204f7f4");
+        map.setReplyEndpoint(KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous));
+
+//      NOT SUPPORTED ATM
+        //map.setRelationship();
+        //map.setReferenceParameters();
+
+        // and with content request
+        const QString action = QString::fromLatin1("sayHello");
+        message.setUse(KDSoapMessage::EncodedUse);
+        message.addArgument(QString::fromLatin1("msg"), QVariant::fromValue(QString("HelloContentMessage")), KDSoapNamespaceManager::xmlSchema2001(), QString::fromLatin1("string"));
+        message.setNamespaceUri(QString::fromLatin1("http://www.ecerami.com/wsdl/HelloService.wsdl"));
+
+        // WHEN
+        message.setMessageAddressingProperties(map);
+        KDSoapMessage reply = client.call(QLatin1String("sayHello"), message, action);
+//        qDebug() << "--- reply received to client" << reply.toXml() << "\n"; // TODO : check how is the server currently responding to this
+
+        // THEN
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage()));
+    }
+
+    void shouldRecognizeWSAddressingFeatureFromWSDL()
+    {
+        HttpServerThread server(QByteArray(), HttpServerThread::Public);
+        Hello_Service service;
+        service.setEndPoint(server.endPoint());
+        service.sayHello("Hi !");
+
+        // TODO: all these properties should match wsdl and or default value
+        // following specifications
+
+//        <wsa:To>xs:anyURI</wsa:To> ?
+//        <wsa:From>wsa:EndpointReferenceType</wsa:From> ?
+//        <wsa:ReplyTo>wsa:EndpointReferenceType</wsa:ReplyTo> ?
+//        <wsa:FaultTo>wsa:EndpointReferenceType</wsa:FaultTo> ?
+//        <wsa:Action>xs:anyURI</wsa:Action>
+//        <wsa:MessageID>xs:anyURI</wsa:MessageID> ?
+//        <wsa:RelatesTo RelationshipType="xs:anyURI"?>xs:anyURI</wsa:RelatesTo> *
+//        <wsa:ReferenceParameters>xs:any*</wsa:ReferenceParameters> ?
+
+        // NEED TO add implicit / explicit recognition
+    }
+private:
+        static QByteArray expectedSoapMessage() {
+            return QByteArray(xmlEnvBegin11()) + " xmlns:wsa=\"http://www.w3.org/2005/08/addressing\""
+                                               + " xmlns:n1=\"http://www.ecerami.com/wsdl/HelloService.wsdl\">"
+                    "<soap:Header>"
+                        "<wsa:To>http://www.ecerami.com/wsdl/HelloService</wsa:To>"
+                         "<wsa:From>"
+                            "<wsa:Address>http://www.ecerami.com/wsdl/source</wsa:Address>"
+                        "</wsa:From>"
+                        "<wsa:ReplyTo>"
+                            "<wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>"
+                        "</wsa:ReplyTo>"
+                        "<wsa:FaultTo>"
+                            "<wsa:Address>http://www.ecerami.com/wsdl/fault</wsa:Address>"
+                        "</wsa:FaultTo>"
+                        "<wsa:Action>sayHello</wsa:Action>"
+                        "<wsa:MessageID>uuid:e197db59-0982-4c9c-9702-4234d204f7f4</wsa:MessageID>"
+                    "</soap:Header>"
+                    "<soap:Body>"
+                      "<n1:sayHello><msg xsi:type=\"xsd:string\">HelloContentMessage</msg></n1:sayHello>"
+//                      "<n1:sayHello xsi:type=\"xsd:string\">HelloContentMessage</n1:sayHello>"
+                    "</soap:Body>" + xmlEnvEnd();
+        }
+
+        static QByteArray emptyResponse() {
+            return QByteArray(xmlEnvBegin11()) + "><soap:Body/>";
+        }
+};
+
+QTEST_MAIN(WSAddressingTest)
+
+#include "wsaddressingtest.moc"


### PR DESCRIPTION
The ws addressing feature is about setting endpoint and other metadata
into the soap header.

We setup a test wsaddressingtest to cover the direct KDSoapClientInterface API
and will extend it to WSDL generation when needed.
KDSoapClient has a new  abstraction class for ws addressing : KDSoapMessageAddressingProperties
which is a simple layer carrying header soap information. KDSoap message is holding a KDSoapMessageAddressingProperties
that is used when writing the soap envelope Futur patch will use this api to generate addressing properties from WSDL file.
Adding KDSoapEndpointReference to KDSoapClient

References :
http://www.w3.org/TR/ws-addr-core/
http://www.w3.org/TR/ws-addr-soap/
http://www.w3.org/TR/ws-addr-wsdl/