### PR TITLE
Fix #65 (error because of cyclic imports)

### DIFF
--- a/autogen/autogen.py
+++ b/autogen/autogen.py
@@ -8,7 +8,7 @@ if sys.version_info[0] != 2:
 
 from cpack import CPackGenerateConfiguration 
 from configure import ConfigureScriptGenerator
-from header import ForwardHeaderGenerator
+import header
 
 def parseSvnInfo( stdout ):
 	lines = stdout.splitlines()
@@ -96,7 +96,7 @@ def autogen(project, version, subprojects, prefixed, forwardHeaderMap = {}, step
 	srcPath = os.path.join( sourceDirectory, "src" )
 
 	if subprojects and "generate-cpack" in steps:
-		forwardHeaderGenerator = ForwardHeaderGenerator( 
+		forwardHeaderGenerator = header.ForwardHeaderGenerator( 
 			copy = True, path = sourceDirectory, includepath = includePath, srcpath = srcPath,
 			project = project, subprojects = subprojects, prefix = installPrefix, prefixed = prefixed,
 			additionalHeaders = forwardHeaderMap			


### PR DESCRIPTION
This should fix the error (issue #65):

    $ python autogen.py 
    Traceback (most recent call last):
      File "autogen.py", line 11, in <module>
        from header import ForwardHeaderGenerator
      File "/path/KDSoap-master/autogen/header.py", line 6, in <module>
        import autogen
      File "/path/KDSoap-master/autogen/autogen.py", line 11, in <module>
        from header import ForwardHeaderGenerator
    ImportError: cannot import name ForwardHeaderGenerator

Please verify this edit and apply it to your repository if it solves that problem.