### PR TITLE
WS Addressing Support

### DIFF
--- a/doc/CHANGES_1_5.txt
+++ b/doc/CHANGES_1_5.txt
@@ -4,7 +4,7 @@ General:
 
 Client-side:
 ============
-*
+* Add WS Addressing Support
 
 Server-side:
 ============

--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
   KDSoapSslHandler.cpp
   KDSoapReplySslHandler.cpp
   KDSoapFaultException.cpp
+  KDSoapMessageAddressingProperties.cpp
+  KDSoapEndpointReference.cpp
 )
 
 add_library(kdsoap ${KDSoap_LIBRARY_MODE} ${SOURCES})
@@ -49,6 +51,8 @@ if(KDSoap_IS_ROOT_PROJECT)
       KDSoapValue,KDSoapValueList
       KDSoapPendingCallWatcher
       KDSoapFaultException
+      KDSoapMessageAddressingProperties
+      KDSoapEndpointReference
       KDSoapPendingCall
       KDSoapAuthentication
     COMMON_HEADER
@@ -70,6 +74,8 @@ if(KDSoap_IS_ROOT_PROJECT)
     KDSoap.h
     KDSoapSslHandler.h
     KDSoapFaultException.h
+    KDSoapMessageAddressingProperties.h
+    KDSoapEndpointReference.h
     DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient
   )
 

--- a/src/KDSoapClient/KDSoapClient.pro
+++ b/src/KDSoapClient/KDSoapClient.pro
@@ -23,7 +23,9 @@ INSTALLHEADERS = KDSoapMessage.h \
     KDSoapNamespaceManager.h \
     KDSoapSslHandler.h \
     KDDateTime.h \
-    KDSoapFaultException.h
+    KDSoapFaultException.h \
+    KDSoapMessageAddressingProperties.cpp \
+    KDSoapEndpointReference.cpp
 PRIVATEHEADERS = KDSoapPendingCall_p.h \
     KDSoapPendingCallWatcher_p.h \
     KDSoapClientInterface_p.h \
@@ -51,7 +53,9 @@ SOURCES = KDSoapMessage.cpp \
     KDSoapJob.cpp \
     KDSoapSslHandler.cpp \
     KDSoapReplySslHandler.cpp \
-    KDSoapFaultException.cpp
+    KDSoapFaultException.cpp \
+    KDSoapMessageAddressingProperties.cpp \
+    KDSoapEndpointReference.cpp
 DEFINES += KDSOAP_BUILD_KDSOAP_LIB
 
 # installation targets:

--- a/src/KDSoapClient/KDSoapClientInterface.h
+++ b/src/KDSoapClient/KDSoapClientInterface.h
@@ -87,7 +87,7 @@ public:
      */
     explicit KDSoapClientInterface(const QString& endPoint, const QString& messageNamespace);
     /**
-     * Destroy the object interface and frees up any resource used.
+     * Destroys the object interface and frees up any resource used.
      * \warning Any running asynchronous calls will be canceled.
      */
     ~KDSoapClientInterface();

--- a/src/KDSoapClient/KDSoapEndpointReference.cpp
+++ b/src/KDSoapClient/KDSoapEndpointReference.cpp
@@ -1,0 +1,70 @@
+#include "KDSoapEndpointReference.h"
+
+#include <QDebug>
+
+class KDSoapEndpointReferenceData : public QSharedData
+{
+public:
+    KDSoapEndpointReferenceData() {}
+
+    QString m_address;
+    KDSoapValueList m_metadata;
+    KDSoapValueList m_referenceParameters;
+};
+
+KDSoapEndpointReference::KDSoapEndpointReference(const QString &address)
+    : d(new KDSoapEndpointReferenceData)
+{
+    d->m_address = address;
+}
+
+KDSoapEndpointReference::KDSoapEndpointReference(const KDSoapEndpointReference &other)
+    : d(other.d)
+{
+}
+
+KDSoapEndpointReference &KDSoapEndpointReference::operator =(const KDSoapEndpointReference &other)
+{
+    d = other.d;
+    return *this;
+}
+
+KDSoapEndpointReference::~KDSoapEndpointReference()
+{
+}
+
+QString KDSoapEndpointReference::address() const
+{
+    return d->m_address;
+}
+
+void KDSoapEndpointReference::setAddress(const QString &address)
+{
+    d->m_address = address;
+}
+
+KDSoapValueList KDSoapEndpointReference::metadata() const
+{
+    return d->m_metadata;
+}
+
+void KDSoapEndpointReference::setMetadata(const KDSoapValueList &metadata)
+{
+    d->m_metadata = metadata;
+}
+
+bool KDSoapEndpointReference::isEmpty() const
+{
+    return d->m_address.isEmpty();
+}
+
+KDSoapValueList KDSoapEndpointReference::referenceParameters() const
+{
+    return d->m_referenceParameters;
+}
+
+void KDSoapEndpointReference::setReferenceParameters(const KDSoapValueList &referenceParameters)
+{
+    d->m_referenceParameters = referenceParameters;
+}
+

--- a/src/KDSoapClient/KDSoapEndpointReference.h
+++ b/src/KDSoapClient/KDSoapEndpointReference.h
@@ -1,0 +1,108 @@
+/****************************************************************************
+** Copyright (C) 2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#ifndef KDSOAPENDPOINTREFERENCE_H
+#define KDSOAPENDPOINTREFERENCE_H
+
+#include "KDSoapGlobal.h"
+#include "KDSoapValue.h"
+#include <QString>
+#include <QSharedDataPointer>
+
+class KDSoapEndpointReferenceData;
+/**
+ * KDSoapEndpointReference is the abstraction class to hold
+ * an Endpoint Reference properties.
+ *
+ * \see: http://www.w3.org/TR/ws-addr-core/#eprinfoset
+ * \since 1.5
+ */
+class KDSOAP_EXPORT KDSoapEndpointReference
+{
+  public:
+
+    /**
+     * Construct a KDSoapEndpointReference object with the given \p address
+     * If no address is given, then an empty QString is taken
+     */
+    explicit KDSoapEndpointReference(const QString &address = QString());
+
+    /**
+     * Copy constructor of KDSoapEndpointReference
+     */
+    KDSoapEndpointReference(const KDSoapEndpointReference &other);
+
+    /**
+     * Copy the content of the KDSoapEndpointReference from \p other to the object
+     */
+    KDSoapEndpointReference &operator =(const KDSoapEndpointReference &other);
+
+    /**
+      * Destroys the object and frees up any resource used.
+      */
+    ~KDSoapEndpointReference();
+
+    /**
+     * Returns the address
+     */
+    QString address() const;
+
+    /**
+     * Sets the address of the endpoint reference
+     * @param address
+     */
+    void setAddress(const QString &address);
+
+    /**
+     * Return the reference parameters, which can be of any types
+     * so we return a KDSoapValueList.
+     */
+    KDSoapValueList referenceParameters() const;
+
+    /**
+     * Sets the reference parameters
+     */
+    void setReferenceParameters(const KDSoapValueList &referenceParameters);
+
+    /**
+     * Return the meta data, which can be of any types
+     * so we return a KDSoapValueList
+     */
+    KDSoapValueList metadata() const;
+
+    /**
+     * Sets the meta data
+     */
+    void setMetadata(const KDSoapValueList &metadata);
+
+    /**
+     * Return true when the address has not been set
+     */
+    bool isEmpty() const;
+
+private:
+    QSharedDataPointer<KDSoapEndpointReferenceData> d;
+};
+
+#endif // KDSOAPENDPOINTREFERENCE_H
+

--- a/src/KDSoapClient/KDSoapMessage.cpp
+++ b/src/KDSoapClient/KDSoapMessage.cpp
@@ -32,11 +32,13 @@ class KDSoapMessageData : public QSharedData
 {
 public:
     KDSoapMessageData()
-        : use(KDSoapMessage::LiteralUse), isFault(false)
+        : use(KDSoapMessage::LiteralUse), isFault(false), hasMessageAddressingProperties(false)
     {}
 
     KDSoapMessage::Use use;
     bool isFault;
+    bool hasMessageAddressingProperties;
+    KDSoapMessageAddressingProperties messageAddressingProperties;
 };
 
 KDSoapMessage::KDSoapMessage()
@@ -131,6 +133,22 @@ QString KDSoapMessage::faultAsString() const
 void KDSoapMessage::setFault(bool fault)
 {
     d->isFault = fault;
+}
+
+KDSoapMessageAddressingProperties KDSoapMessage::messageAddressingProperties() const
+{
+    return d->messageAddressingProperties;
+}
+
+void KDSoapMessage::setMessageAddressingProperties(const KDSoapMessageAddressingProperties &map)
+{
+    d->messageAddressingProperties = map;
+    d->hasMessageAddressingProperties = true;
+}
+
+bool KDSoapMessage::hasMessageAddressingProperties() const
+{
+    return d->hasMessageAddressingProperties;
 }
 
 KDSoapMessage::Use KDSoapMessage::use() const

--- a/src/KDSoapClient/KDSoapMessage.h
+++ b/src/KDSoapClient/KDSoapMessage.h
@@ -25,7 +25,10 @@
 
 #include <QtCore/QSharedDataPointer>
 #include <QtCore/QVariant>
+
 #include "KDSoapValue.h"
+#include "KDSoapMessageAddressingProperties.h"
+
 QT_BEGIN_NAMESPACE
 class QString;
 QT_END_NAMESPACE
@@ -148,6 +151,27 @@ public:
      */
     void setFault(bool fault);
 
+    /**
+     * Attach to a KDSoapMessage the message addressing properties that will be written
+     * in its header.
+     * Calling this will make hasMessageAddressingProperties() return true.
+     * \since 1.5
+     */
+    void setMessageAddressingProperties(const KDSoapMessageAddressingProperties &map);
+
+    /**
+     * Return whether a KDSoapMessageAddressingProperties has been set for this
+     * KDSoapMessage
+     * \since 1.5
+     */
+    bool hasMessageAddressingProperties() const;
+
+    /**
+     * Return the messageAddressingProperties related to the KDSoapMessage
+     * \see KDSoapMessageAddressingProperties
+     * \since 1.5
+     */
+    KDSoapMessageAddressingProperties messageAddressingProperties() const;
 private:
     bool isNull() const;
     friend class KDSoapPendingCall;

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -1,0 +1,330 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+#include "KDSoapMessageAddressingProperties.h"
+
+#include "KDSoapNamespacePrefixes_p.h"
+#include "KDSoapNamespaceManager.h"
+
+#include <QDebug>
+#include <QLatin1String>
+#include <QString>
+#include <QXmlStreamWriter>
+
+class KDSoapMessageAddressingPropertiesData : public QSharedData
+{
+public:
+
+    QString destination;    // Provides the address of the intended receiver of this message
+    QString action;         // Identifies the semantics implied by this message
+    KDSoapEndpointReference sourceEndpoint; // Message origin, could be included to facilitate longer running message exchanges.
+    KDSoapEndpointReference replyEndpoint;  // Intended receiver for replies to this message, could be included to facilitate longer running message exchanges.
+    KDSoapEndpointReference faultEndpoint;  // Intended receiver for faults related to this message, could be included to facilitate longer running message exchanges.
+    QString messageID;      // Unique identifier for this message, may be included to facilitate longer running message exchanges.
+    QVector<KDSoapMessageRelationship::Relationship> relationships;   // Indicates relationships to prior messages, could be included to facilitate longer running message exchanges.
+    KDSoapValueList referenceParameters; // Equivalent of the reference parameters object from the endpoint reference within WSDL file
+    KDSoapValueList metadata; // Holding metadata information
+};
+
+KDSoapMessageAddressingProperties::KDSoapMessageAddressingProperties()
+    : d(new KDSoapMessageAddressingPropertiesData)
+{
+}
+
+KDSoapMessageAddressingProperties::KDSoapMessageAddressingProperties(const KDSoapMessageAddressingProperties &other)
+    : d(other.d)
+{
+}
+
+KDSoapMessageAddressingProperties &KDSoapMessageAddressingProperties::operator =(const KDSoapMessageAddressingProperties &other)
+{
+    d = other.d;
+    return *this;
+}
+
+QString KDSoapMessageAddressingProperties::destination() const
+{
+    return d->destination;
+}
+
+void KDSoapMessageAddressingProperties::setDestination(const QString &destination)
+{
+    d->destination = destination;
+}
+
+QString KDSoapMessageAddressingProperties::action() const
+{
+    return d->action;
+}
+
+void KDSoapMessageAddressingProperties::setAction(const QString &action)
+{
+    d->action = action;
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::sourceEndpoint() const
+{
+    return d->sourceEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::sourceEndpointAddress() const
+{
+    return d->sourceEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setSourceEndpoint(const KDSoapEndpointReference &sourceEndpoint)
+{
+    d->sourceEndpoint = sourceEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setSourceEndpointAddress(const QString &sourceEndpoint)
+{
+    d->sourceEndpoint.setAddress(sourceEndpoint);
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::replyEndpoint() const
+{
+    return d->replyEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::replyEndpointAddress() const
+{
+    return d->replyEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setReplyEndpoint(const KDSoapEndpointReference &replyEndpoint)
+{
+    d->replyEndpoint = replyEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setReplyEndpointAddress(const QString &replyEndpoint)
+{
+    d->replyEndpoint.setAddress(replyEndpoint);
+}
+
+KDSoapEndpointReference KDSoapMessageAddressingProperties::faultEndpoint() const
+{
+    return d->faultEndpoint;
+}
+
+QString KDSoapMessageAddressingProperties::faultEndpointAddress() const
+{
+    return d->faultEndpoint.address();
+}
+
+void KDSoapMessageAddressingProperties::setFaultEndpoint(const KDSoapEndpointReference &faultEndpoint)
+{
+    d->faultEndpoint = faultEndpoint;
+}
+
+void KDSoapMessageAddressingProperties::setFaultEndpointAddress(const QString &faultEndpoint)
+{
+    d->faultEndpoint.setAddress(faultEndpoint);
+}
+
+QString KDSoapMessageAddressingProperties::messageID() const
+{
+    return d->messageID;
+}
+
+void KDSoapMessageAddressingProperties::setMessageID(const QString &id)
+{
+    d->messageID = id;
+}
+
+QVector<KDSoapMessageRelationship::Relationship> KDSoapMessageAddressingProperties::relationships() const
+{
+    return d->relationships;
+}
+
+void KDSoapMessageAddressingProperties::setRelationships(const QVector<KDSoapMessageRelationship::Relationship> &relationships)
+{
+    d->relationships = relationships;
+}
+
+void KDSoapMessageAddressingProperties::addRelationship(const KDSoapMessageRelationship::Relationship &relationship)
+{
+    d->relationships.append(relationship);
+}
+
+KDSoapValueList KDSoapMessageAddressingProperties::referenceParameters() const
+{
+    return d->referenceParameters;
+}
+
+void KDSoapMessageAddressingProperties::setReferenceParameters(const KDSoapValueList &values)
+{
+    d->referenceParameters = values;
+}
+
+void KDSoapMessageAddressingProperties::addReferenceParameter(const KDSoapValue &oneReferenceParameter)
+{
+    if (!oneReferenceParameter.isNull())
+        d->referenceParameters.append(oneReferenceParameter);
+}
+
+KDSoapValueList KDSoapMessageAddressingProperties::metadata() const
+{
+    return d->metadata;
+}
+
+void KDSoapMessageAddressingProperties::setMetadata(const KDSoapValueList &metadataList)
+{
+    d->metadata = metadataList;
+}
+
+void KDSoapMessageAddressingProperties::addMetadata(const KDSoapValue &metadata)
+{
+    if (!metadata.isNull())
+        d->metadata.append(metadata);
+}
+
+KDSoapMessageAddressingProperties::~KDSoapMessageAddressingProperties()
+{
+}
+
+QString KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::KDSoapAddressingPredefinedAddress address)
+{
+    switch (address) {
+        case Anonymous:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/anonymous");
+        case None:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/none");
+        case Reply:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/reply");
+        case Unspecified:
+            return QLatin1String("http://www.w3.org/2005/08/addressing/unspecified");
+        default:
+            Q_ASSERT(false); // should never happen
+            return QString();
+    }
+}
+
+static void writeAddressField(QXmlStreamWriter &writer, const QString& address)
+{
+    writer.writeStartElement(KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("Address"));
+    writer.writeCharacters(address);
+    writer.writeEndElement();
+}
+
+static void writeKDSoapValueVariant(QXmlStreamWriter &writer, const KDSoapValue& value)
+{
+    const QVariant valueToWrite = value.value();
+    if (valueToWrite.canConvert(QVariant::String))
+        writer.writeCharacters(valueToWrite.toString());
+    else
+        qWarning("Warning: KDSoapMessageAddressingProperties call to writeKDSoapValueVariant could not write the given KDSoapValue "
+                 "value because it could not be converted into a QString");
+}
+
+static void writeKDSoapValueListHierarchy(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const KDSoapValueList &values)
+{
+    const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
+
+    Q_FOREACH (const KDSoapValue &value, values)  {
+        const QString topLevelName = value.name();
+        writer.writeStartElement(addressingNS, topLevelName);
+
+        if (value.childValues().isEmpty())
+            writeKDSoapValueVariant(writer, value);
+        else
+            writeKDSoapValueListHierarchy(namespacePrefixes, writer, value.childValues());
+
+        writer.writeEndElement();
+    }
+}
+
+void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const
+{
+    if (d->destination == predefinedAddressToString(None) || d->destination.isEmpty())
+        return;
+
+    if (d->action.isEmpty())
+        return;
+
+    const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
+
+    writer.writeStartElement(addressingNS, QLatin1String("To"));
+    writer.writeCharacters(d->destination);
+    writer.writeEndElement();
+
+    writer.writeStartElement(addressingNS, QLatin1String("From"));
+    writeAddressField(writer, d->sourceEndpoint.address());
+    writer.writeEndElement();
+
+    if (!d->replyEndpoint.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("ReplyTo"));
+        writeAddressField(writer, d->replyEndpoint.address());
+        writer.writeEndElement();
+    }
+
+    if (!d->faultEndpoint.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("FaultTo"));
+        writeAddressField(writer, d->faultEndpoint.address());
+        writer.writeEndElement();
+    }
+
+    if (!d->action.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("Action"));
+        writer.writeCharacters(d->action);
+        writer.writeEndElement();
+    }
+
+    if (!d->messageID.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("MessageID"));
+        writer.writeCharacters(d->messageID);
+        writer.writeEndElement();
+    }
+
+    foreach(const KDSoapMessageRelationship::Relationship &relationship, d->relationships) {
+        if (relationship.uri.isEmpty())
+            continue;
+
+        writer.writeStartElement(addressingNS, QLatin1String("RelatesTo"));
+
+        if (!relationship.relationshipType.isEmpty())
+            writer.writeAttribute(QLatin1String("RelationshipType"), relationship.relationshipType);
+
+        writer.writeCharacters(relationship.uri);
+        writer.writeEndElement();
+    }
+
+    if (!d->referenceParameters.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("ReferenceParameters"));
+        writeKDSoapValueListHierarchy(namespacePrefixes, writer, d->referenceParameters);
+        writer.writeEndElement();
+    }
+
+    if (!d->metadata.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("Metadata"));
+        writeKDSoapValueListHierarchy(namespacePrefixes, writer, d->metadata);
+        writer.writeEndElement();
+    }
+}
+
+QDebug operator <<(QDebug dbg, const KDSoapMessageAddressingProperties &msg)
+{
+    dbg << msg.action() << msg.destination() << msg.sourceEndpoint().address() << msg.replyEndpoint().address() << msg.faultEndpoint().address() << msg.messageID();
+
+    return dbg;
+}
+

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.h
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.h
@@ -1,0 +1,290 @@
+/****************************************************************************
+** Copyright (C) 2010-2015 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+#ifndef KDSOAPMESSAGEADDRESSINGPROPERTIES_H
+#define KDSOAPMESSAGEADDRESSINGPROPERTIES_H
+
+#include <QtCore/QSharedDataPointer>
+#include "KDSoapGlobal.h"
+
+#include "KDSoapEndpointReference.h"
+#include "KDSoapValue.h"
+
+QT_BEGIN_NAMESPACE
+class QString;
+QT_END_NAMESPACE
+
+class KDSoapNamespacePrefixes;
+class KDSoapMessageAddressingPropertiesData;
+
+
+/**
+ * Relationship between two soap messages.
+ * This class is composed of two QStrings: one represents the type of the relation, the other represents the message ID of the message it refers to.
+ *
+ * \see http://www.w3.org/TR/ws-addr-core/#msgaddrpropsinfoset
+ * \since 1.5
+ */
+namespace KDSoapMessageRelationship {
+
+struct Relationship
+{
+    /**
+     * Relationship default ctor
+     */
+    Relationship() {}
+
+    /**
+     * Relationship constructor
+     * @param URI is supposed to represent a message ID of a previous message you want to make reference to
+     * @param type represents the nature of the relation between messages, if none is provided, the following
+     * predefined address will be used http://www.w3.org/2005/08/addressing/reply
+     */
+    Relationship(const QString &URI, const QString &type = QString())
+        : uri(URI), relationshipType(type){}
+
+    QString uri;
+    QString relationshipType;
+};
+
+} // namespace
+
+/**
+ * The KDSoapMessageAddressingProperties class is the abstraction of the
+ * WS-Addressing specification. This specification sets up information within the
+ * soap envelope header. This class is meant to be filled with the data you want
+ * to have in the soap header and associate to a given message using
+ * \see KDSoapMessage::setMessageAddressingProperties
+ *
+ * \see http://www.w3.org/TR/ws-addr-core/#abstractmaps
+ * Important: This class does not ensure any kind of validation to the data being passed to it
+ * \since 1.5
+ */
+
+class KDSOAP_EXPORT KDSoapMessageAddressingProperties
+{
+public:
+    friend class KDSoapMessageWriter;
+
+    /**
+     * This enum contains all the predefined addresses defined by the ws addressing specification
+     * It is meant to be used with the predefinedAddress helper function to retrieve the uri as a QString
+     * \see predefinedAddressToString
+     */
+    enum KDSoapAddressingPredefinedAddress {
+        None,
+        Anonymous,
+        Reply,
+        Unspecified
+    };
+
+    /**
+     * Constructs an empty KDSoapMessageAddressingProperties object.
+     */
+    KDSoapMessageAddressingProperties();
+
+    /**
+     * Destructs the KDSoapMessageAddressingProperties object.
+     */
+    ~KDSoapMessageAddressingProperties();
+
+    /**
+     * Constructs a copy of the KDSoapMessageAddressingProperties object given by \p other.
+     */
+    KDSoapMessageAddressingProperties(const KDSoapMessageAddressingProperties &other);
+
+    /**
+     * Copies the contents of the object given by \p other.
+     */
+    KDSoapMessageAddressingProperties &operator =(const KDSoapMessageAddressingProperties &other);
+
+    /**
+     * Returns the destination address, it should match the EndpointReference given from WSDL
+     */
+    QString destination() const;
+
+    /**
+     * Sets the destination address, where the message will be sent to
+     */
+    void setDestination(const QString &destination);
+
+    /**
+     * Returns the action uri, which is the semantic of the message
+     */
+    QString action() const;
+
+    /**
+     * Sets the targeted action of the soap message
+     */
+    void setAction(const QString& action);
+
+    /**
+     * Returns the message sender endpoint
+     * \see KDSoapEndpointReference
+     */
+    KDSoapEndpointReference sourceEndpoint() const;
+
+    /**
+     * Convenient method, returns directly the source endpoint address
+     * \see KDSoapAddressingPredefinedAddress enum
+     */
+    QString sourceEndpointAddress() const;
+
+    /**
+     * Sets the message sender endpoint
+     * \see KDSoapEndpointReference
+     */
+    void setSourceEndpoint(const KDSoapEndpointReference &sourceEndpoint);
+
+    /**
+     * Convenient method, sets the message sender address
+     */
+    void setSourceEndpointAddress(const QString &sourceEndpoint);
+
+    /**
+     * Returns the reply endpoint
+     * \see KDSoapAddressingPredefinedAddress enum
+     */
+    KDSoapEndpointReference replyEndpoint() const;
+
+    /**
+     * Convenient method, returns the sender endpoint address
+     */
+    QString replyEndpointAddress() const;
+
+    /**
+     * Sets the reply endpoint the server should reply to
+     * \see KDSoapEndpointReference
+     */
+    void setReplyEndpoint(const KDSoapEndpointReference &replyEndpoint);
+
+    /**
+     * Convenient method to set directly the reply endpoint address the server should reply to
+     */
+    void setReplyEndpointAddress(const QString &replyEndpoint);
+
+    /**
+     * Returns the fault endpoint, which contains the address the server should send the potential fault error
+     */
+    KDSoapEndpointReference faultEndpoint() const;
+
+    /**
+     * Convenient method that returns the fault endpoint address, which is the address the server should send the potential fault error
+     */
+    QString faultEndpointAddress() const;
+
+    /**
+     * Set the fault endpoint of the message
+     * \see KDSoapEndpointReference
+     */
+    void setFaultEndpoint(const KDSoapEndpointReference &faultEndpoint);
+
+    /**
+     * Convenient method to set directly the fault endpoint address of the message
+     */
+    void setFaultEndpointAddress(const QString &faultEndpoint);
+
+    /**
+     * Returns the message id
+     */
+    QString messageID() const;
+
+    /**
+     * Set the message id
+     */
+    void setMessageID(const QString &id);
+
+    /**
+     * Return the relationship of the KDSoapMessageAddressingProperties
+     *
+     * \see Relationship
+     */
+    QVector<KDSoapMessageRelationship::Relationship> relationships() const;
+
+    /**
+     * Set the relationships of the message, parameter is a QVector of Relationship, the class Relationship carry the relationship type and the message ID of the related message
+     *
+     * \see Relationship
+     *
+     */
+    void setRelationships(const QVector<KDSoapMessageRelationship::Relationship> &relationships);
+
+    /**
+     * Convenient method to add a single Relationship to the message
+     *
+     * \see Relationship
+     *
+     */
+    void addRelationship(const KDSoapMessageRelationship::Relationship &relationship);
+
+    /**
+     * Returns the custom reference parameters objects as a KDSoapValueList
+     */
+    KDSoapValueList referenceParameters() const;
+
+    /**
+     * Set the reference parameters list, since this value can be anything custom, it uses a KDSoapValueList
+     */
+    void setReferenceParameters(const KDSoapValueList &values);
+
+    /**
+     * Add a reference parameter, if not null, to the referenceParameters list
+     */
+    void addReferenceParameter(const KDSoapValue &oneReferenceParameter);
+
+    /**
+     * Returns the metadata of the KDSoapMessageProperties
+     */
+    KDSoapValueList metadata() const;
+
+    /**
+     * Set the metadata field, can be a multi level KDSoapValueList
+     */
+    void setMetadata(const KDSoapValueList &metadataList);
+
+    /**
+     * Add one metadata, if not null, to the list of metadata that will apear within soap header
+     */
+    void addMetadata(const KDSoapValue &metadata);
+
+    /**
+     * Helper function that takes the \p address enum to provide the QString equivalent
+     */
+    static QString predefinedAddressToString(KDSoapAddressingPredefinedAddress address);
+
+private:
+    /**
+     * Private method called to write the properties to the soap header, using QXmlStreamWriter
+     */
+    void writeMessageAddressingProperties(KDSoapNamespacePrefixes& namespacePrefixes, QXmlStreamWriter& writer, const QString& messageNamespace, bool forceQualified) const;
+
+private:
+    QSharedDataPointer<KDSoapMessageAddressingPropertiesData> d;
+};
+
+
+/**
+ * Support for debugging KDSoapMessageAddressingProperties object via qDebug() << msg;
+ */
+KDSOAP_EXPORT QDebug operator <<(QDebug dbg, const KDSoapMessageAddressingProperties &msg);
+
+#endif // KDSOAPMESSAGEADDRESSINGPROPERTIES_H

--- a/src/KDSoapClient/KDSoapNamespaceManager.cpp
+++ b/src/KDSoapClient/KDSoapNamespaceManager.cpp
@@ -65,3 +65,8 @@ QString KDSoapNamespaceManager::soapEncoding200305()
 {
     return QString::fromLatin1("http://www.w3.org/2003/05/soap-encoding");
 }
+
+QString KDSoapNamespaceManager::soapMessageAddressing()
+{
+    return QString::fromLatin1("http://www.w3.org/2005/08/addressing");
+}

--- a/src/KDSoapClient/KDSoapNamespaceManager.h
+++ b/src/KDSoapClient/KDSoapNamespaceManager.h
@@ -40,6 +40,7 @@ public:
     static QString soapEnvelope200305();
     static QString soapEncoding();
     static QString soapEncoding200305();
+    static QString soapMessageAddressing();
 
 private: // TODO instantiate to handle custom namespaces per clientinterface
     KDSoapNamespaceManager();

--- a/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
@@ -25,7 +25,8 @@
 #include "KDSoapNamespaceManager.h"
 
 void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter& writer,
-                                                      KDSoapClientInterface::SoapVersion version)
+                                                      KDSoapClientInterface::SoapVersion version,
+                                                      bool messageAddressingEnabled)
 {
     if (version == KDSoapClientInterface::SOAP1_1) {
         writeNamespace(writer, KDSoapNamespaceManager::soapEnvelope(), QLatin1String("soap"));
@@ -37,6 +38,10 @@ void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter& writer,
 
     writeNamespace(writer, KDSoapNamespaceManager::xmlSchema2001(), QLatin1String("xsd"));
     writeNamespace(writer, KDSoapNamespaceManager::xmlSchemaInstance2001(), QLatin1String("xsi"));
+
+    if (messageAddressingEnabled) {
+        writeNamespace(writer, KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("wsa"));
+    }
 
     // Also insert known variants
     insert(KDSoapNamespaceManager::xmlSchema1999(), QString::fromLatin1("xsd"));

--- a/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
@@ -32,7 +32,8 @@ class KDSoapNamespacePrefixes : public QMap<QString /*ns*/, QString /*prefix*/>
 {
 public:
     void writeStandardNamespaces(QXmlStreamWriter& writer,
-                                 KDSoapClientInterface::SoapVersion version = KDSoapClientInterface::SOAP1_1);
+                                 KDSoapClientInterface::SoapVersion version = KDSoapClientInterface::SOAP1_1,
+                                 bool messageAddressingEnabled = false);
 
     void writeNamespace(QXmlStreamWriter& writer, const QString& ns, const QString& prefix) {
         //qDebug() << "writeNamespace" << ns << prefix;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(onvif_ptz)
 add_subdirectory(encapsecurity)
 add_subdirectory(prefix_wsdl)
 add_subdirectory(vidyo)
+add_subdirectory(ws_addressing_support)
 
 # These need internet access
 add_subdirectory(webcalls)

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -35,6 +35,7 @@ SUBDIRS = \
   encapsecurity \
   prefix_wsdl \
   vidyo \
+  ws_addressing_support
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl

--- a/unittests/ws_addressing_support/CMakeLists.txt
+++ b/unittests/ws_addressing_support/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(ws_addressing_support)
+
+set(WSDL_FILES wsaddressing.wsdl)
+set(ws_addressing_support_SRCS wsaddressing.cpp )
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${ws_addressing_support_SRCS} )

--- a/unittests/ws_addressing_support/ws_addressing_support.pro
+++ b/unittests/ws_addressing_support/ws_addressing_support.pro
@@ -1,0 +1,9 @@
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += network xml
+SOURCES = wsaddressingtest.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = wsaddressing.wsdl

--- a/unittests/ws_addressing_support/wsaddressing.wsdl
+++ b/unittests/ws_addressing_support/wsaddressing.wsdl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="HelloService"
+   targetNamespace="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns="http://schemas.xmlsoap.org/wsdl/"
+   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+   xmlns:tns="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns:wsa="http://www.w3.org/2005/08/addressing"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+   <message name="SayHelloRequest">
+      <part name="msg" type="xsd:string"/>
+   </message>
+   <message name="SayHelloResponse">
+      <part name="reply" type="xsd:string"/>
+   </message>
+
+   <portType name="Hello_PortType">
+      <operation name="sayHello">
+         <input message="tns:SayHelloRequest" wsaw:Action="http://localhost:8081/hello"/>
+         <output message="tns:SayHelloResponse" wsaw:Action="http://localhost:8081/hello"/>
+      </operation>
+   </portType>
+
+   <binding name="Hello_Binding" type="tns:Hello_PortType">
+      <wsaw:UsingAddressing wsdl:required="true" /> <!--NEED TO BE TAKEN INTO ACCOUNT -->
+      <soap:binding style="document"
+         transport="http://schemas.xmlsoap.org/soap/http"/>
+      <operation name="sayHello" style="document">
+         <soap:operation soapAction="sayHello"/>
+         <input wsaw:Action="http://localhost:8081/hello">
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </input>
+         <output>
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </output>
+      </operation>
+</binding>
+
+   <service name="Hello_Service">
+      <documentation>WSDL File for HelloService</documentation>
+      <port binding="tns:Hello_Binding" name="Hello_Port">
+         <soap:address location="http://localhost:8081/hello" />
+
+         <wsa:EndpointReference
+             xmlns:example="http://example.com/namespace"
+             xmlns:wsdli="http://www.w3.org/2006/01/wsdl-instance"
+             wsdli:wsdlLocation="http://example.com/location">
+
+             <wsa:Address>http://localhost:8081/hello</wsa:Address>
+             <wsa:Metadata>
+                <wsam:InterfaceName>example:Inventory</wsam:InterfaceName>
+             </wsa:Metadata>
+             <wsa:ReferenceParameters>
+               <example:AccountCode>123456789</example:AccountCode>
+               <example:DiscountId>ABCDEFG</example:DiscountId>
+             </wsa:ReferenceParameters>
+         </wsa:EndpointReference>
+
+      </port>
+   </service>
+</definitions>

--- a/unittests/ws_addressing_support/wsaddressingtest.cpp
+++ b/unittests/ws_addressing_support/wsaddressingtest.cpp
@@ -1,0 +1,166 @@
+/****************************************************************************
+** Copyright (C) 2010-2014 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "httpserver_p.h"
+
+#include <QtTest/QtTest>
+#include <QDebug>
+#include <QObject>
+
+#include "KDSoapClient/KDSoapMessageWriter_p.h"
+#include "KDSoapClient/KDSoapMessageAddressingProperties.h"
+#include "KDSoapNamespaceManager.h"
+#include "wsdl_wsaddressing.h"
+
+using namespace KDSoapUnitTestHelpers;
+
+class WSAddressingTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void shouldProvideCorrectPredefinedAddresses()
+    {
+        QString none = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::None);
+        QCOMPARE(none, QString("http://www.w3.org/2005/08/addressing/none"));
+
+        QString anonymous = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous);
+        QCOMPARE(anonymous, QString("http://www.w3.org/2005/08/addressing/anonymous"));
+
+        QString reply = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Reply);
+        QCOMPARE(reply, QString("http://www.w3.org/2005/08/addressing/reply"));
+
+        QString unspecified = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Unspecified);
+        QCOMPARE(unspecified, QString("http://www.w3.org/2005/08/addressing/unspecified"));
+    }
+
+    void shouldWriteAProperSoapMessageWithRightsAddressingProperties()
+    {
+        // GIVEN
+        HttpServerThread server(emptyResponse(), HttpServerThread::Public);
+        KDSoapClientInterface client(server.endPoint(), "http://www.ecerami.com/wsdl/HelloService");
+
+        KDSoapMessage message;
+        KDSoapMessageAddressingProperties map;
+
+        // with some message addressing properties
+        map.setAction("sayHello");
+        map.setDestination("http://www.ecerami.com/wsdl/HelloService");
+        map.setSourceEndpointAddress("http://www.ecerami.com/wsdl/source");
+        map.setFaultEndpoint(KDSoapEndpointReference("http://www.ecerami.com/wsdl/fault"));
+        map.setMessageID("uuid:e197db59-0982-4c9c-9702-4234d204f7f4");
+        map.setReplyEndpointAddress(KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous));
+
+        // two relationships related to previous message
+        KDSoapMessageRelationship::Relationship relationship("uuid:http://www.ecerami.com/wsdl/someUniqueString"); // no type means implicit Reply
+        KDSoapMessageRelationship::Relationship relationshipBis("uuid:http://www.ecerami.com/wsdl/someUniqueStringBis", "CustomTypeReply");
+        map.addRelationship(relationship);
+        map.addRelationship(relationshipBis);
+
+        // some reference parameters...
+
+            // one with a value
+        KDSoapValue refParam("myReferenceParameter", "ReferencParameterContent");
+        map.addReferenceParameter(refParam);
+
+            // an other one, with children
+        KDSoapValue childOne("myReferenceParameterChildOne", "ChildOneContent");
+        KDSoapValue childTwo("myReferenceParameterChildTwo", "ChildTwoContent");
+        KDSoapValueList childrenList;
+        childrenList << childOne << childTwo;
+        KDSoapValue refParamWithChildren("myReferenceParameterWithChildren", childrenList);
+        map.addReferenceParameter(refParamWithChildren);
+
+        // some metadata
+        KDSoapValueList metadataContainer;
+        KDSoapValue metadata("myMetadata", "MetadataContent");
+        metadataContainer << metadata;
+
+        KDSoapValue child("myMetadataBisChild", "MetadataBisChildContent");
+        KDSoapValueList childList; childList << child;
+        KDSoapValue metadataBis("myMetadataBis", childList);
+
+        map.setMetadata(metadataContainer);
+        map.addMetadata(metadataBis);
+
+        // and some request content
+        const QString action = QString::fromLatin1("sayHello");
+        message.setUse(KDSoapMessage::EncodedUse);
+        message.addArgument(QString::fromLatin1("msg"), QVariant::fromValue(QString("HelloContentMessage")), KDSoapNamespaceManager::xmlSchema2001(), QString::fromLatin1("string"));
+        message.setNamespaceUri(QString::fromLatin1("http://www.ecerami.com/wsdl/HelloService.wsdl"));
+
+        // WHEN
+        message.setMessageAddressingProperties(map);
+        KDSoapMessage reply = client.call(QLatin1String("sayHello"), message, action);
+
+        // THEN
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage()));
+    }
+
+private:
+        static QByteArray expectedSoapMessage() {
+            return QByteArray(xmlEnvBegin11()) + " xmlns:wsa=\"http://www.w3.org/2005/08/addressing\""
+                                               + " xmlns:n1=\"http://www.ecerami.com/wsdl/HelloService.wsdl\">"
+                    "<soap:Header>"
+                        "<wsa:To>http://www.ecerami.com/wsdl/HelloService</wsa:To>"
+                         "<wsa:From>"
+                            "<wsa:Address>http://www.ecerami.com/wsdl/source</wsa:Address>"
+                        "</wsa:From>"
+                        "<wsa:ReplyTo>"
+                            "<wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>"
+                        "</wsa:ReplyTo>"
+                        "<wsa:FaultTo>"
+                            "<wsa:Address>http://www.ecerami.com/wsdl/fault</wsa:Address>"
+                        "</wsa:FaultTo>"
+                        "<wsa:Action>sayHello</wsa:Action>"
+                        "<wsa:MessageID>uuid:e197db59-0982-4c9c-9702-4234d204f7f4</wsa:MessageID>"
+                        "<wsa:RelatesTo>uuid:http://www.ecerami.com/wsdl/someUniqueString</wsa:RelatesTo>"
+                        "<wsa:RelatesTo RelationshipType=\"CustomTypeReply\">uuid:http://www.ecerami.com/wsdl/someUniqueStringBis</wsa:RelatesTo>"
+                        "<wsa:ReferenceParameters>"
+                            "<wsa:myReferenceParameter>ReferencParameterContent</wsa:myReferenceParameter>"
+                            "<wsa:myReferenceParameterWithChildren>"
+                                "<wsa:myReferenceParameterChildOne>ChildOneContent</wsa:myReferenceParameterChildOne>"
+                                "<wsa:myReferenceParameterChildTwo>ChildTwoContent</wsa:myReferenceParameterChildTwo>"
+                            "</wsa:myReferenceParameterWithChildren>"
+                    "</wsa:ReferenceParameters>"
+                    "<wsa:Metadata>"
+                        "<wsa:myMetadata>MetadataContent</wsa:myMetadata>"
+                        "<wsa:myMetadataBis>"
+                            "<wsa:myMetadataBisChild>MetadataBisChildContent</wsa:myMetadataBisChild>"
+                        "</wsa:myMetadataBis>"
+                    "</wsa:Metadata>"
+                    "</soap:Header>"
+                    "<soap:Body>"
+                      "<n1:sayHello><msg xsi:type=\"xsd:string\">HelloContentMessage</msg></n1:sayHello>"
+                    "</soap:Body>" + xmlEnvEnd();
+        }
+
+        static QByteArray emptyResponse() {
+            return QByteArray(xmlEnvBegin11()) + "><soap:Body/>";
+        }
+};
+
+QTEST_MAIN(WSAddressingTest)
+
+#include "wsaddressingtest.moc"


### PR DESCRIPTION
The ws addressing feature is about setting endpoint and other metadata
into the soap header.

We setup a test wsaddressingtest to cover the direct KDSoapClientInterface API
and will extend it to WSDL generation when needed.
KDSoapClient has a new  abstraction class for ws addressing : KDSoapMessageAddressingProperties
which is a simple layer carrying header soap information. KDSoap message is holding a KDSoapMessageAddressingProperties
that is used when writing the soap envelope Futur patch will use this api to generate addressing properties from WSDL file.
Adding KDSoapEndpointReference to KDSoapClient

References :
http://www.w3.org/TR/ws-addr-core/
http://www.w3.org/TR/ws-addr-soap/
http://www.w3.org/TR/ws-addr-wsdl/