### PR TITLE
Fixed incomplete usage of -Wformat-security

### DIFF
--- a/g++.pri
+++ b/g++.pri
@@ -7,7 +7,7 @@
   NORMAL_CXXFLAGS = \
 	-Wnon-virtual-dtor -Wundef -Wcast-align \
 	-Wchar-subscripts -Wpointer-arith \
-	-Wwrite-strings -Wformat-security \
+	-Wwrite-strings -Wformat -Wformat-security \
         -Wmissing-format-attribute -Woverloaded-virtual
 
   # -Wconversion gives too many warnings from Qt-4.4.3 with gcc-4.3.2 (was fine with gcc-4.2.4), so removing it


### PR DESCRIPTION
gcc 5.2.1 otherwise complains about:

 cc1plus: warning: -Wformat-security ignored without -Wformat [-Wformat-security]