### PR TITLE
Make the SSL error test pass with yet another signal variation.

### DIFF
--- a/unittests/wsdl_document/test_wsdl_document.cpp
+++ b/unittests/wsdl_document/test_wsdl_document.cpp
@@ -245,8 +245,12 @@ private Q_SLOTS:
         QVERIFY(errors.count() > 0);
 #ifdef Q_OS_LINUX // Windows seems to get "Unknown error". Bah... And OSX has UnableToVerifyFirstCertificate at position 1.
         QCOMPARE((int)errors.at(0).error(), (int)QSslError::UnableToGetLocalIssuerCertificate);
-        QCOMPARE((int)errors.at(1).error(), (int)QSslError::CertificateUntrusted);
-        QCOMPARE((int)errors.at(2).error(), (int)QSslError::UnableToVerifyFirstCertificate);
+        if (errors.count() > 2) {
+            QCOMPARE((int)errors.at(1).error(), (int)QSslError::CertificateUntrusted);
+            QCOMPARE((int)errors.at(2).error(), (int)QSslError::UnableToVerifyFirstCertificate);
+        } else {
+            QCOMPARE((int)errors.at(1).error(), (int)QSslError::UnableToVerifyFirstCertificate);
+        }
 #endif
 #endif
     }


### PR DESCRIPTION
Getting just these two with Qt 5.4.2 on Debian 'stretch'. Same
as the comment suggests for Mac OS X. Question is which system/Qt
combination had 3 errors.

(This is a rather lame solution and more of a bug report than a bugfix. If the results are really that unportable the check might be easier to dumb down the check and make it just check presence
of 1-2 mandatory errors)