### PR TITLE
Set parsed value to false

### DIFF
--- a/src/KDSoapClient/KDSoapPendingCall.cpp
+++ b/src/KDSoapClient/KDSoapPendingCall.cpp
@@ -94,6 +94,7 @@ void KDSoapPendingCall::Private::parseReply()
 #if QT_VERSION >= 0x040600
     if (!reply->isFinished()) {
         qWarning("KDSoap: Parsing reply before it finished!");
+        parsed = false;
     }
 #endif
     if (reply->error()) {


### PR DESCRIPTION
We're set parsed value to false if reply is not finished. Because returnMessage or returnHeader call method parseReply and when response is not finished and not parsed we're ignore all next callable