### PR TITLE
kdwsdl2cpp: Avoid potential type collisions in nested complexTypes

### DIFF
--- a/kdwsdl2cpp/schema/parser.cpp
+++ b/kdwsdl2cpp/schema/parser.cpp
@@ -520,8 +520,13 @@ Element Parser::parseElement(ParserContext *context,
             //qDebug() << "childName:" << childName.localName();
             if (childName.localName() == QLatin1String("complexType")) {
                 ComplexType ct = parseComplexType(context, childElement);
-
-                ct.setName(newElement.name());
+                QString name = newElement.name();
+                int i = 0;
+                while (!d->mComplexTypes.complexType(QName(ct.nameSpace(), name)).name().isEmpty())
+                    name = newElement.name() + QString::number(++i);
+                if (name != newElement.name() && debugParsing())
+                    qDebug() << " detected potential type collision in nested complexType, updated name" << newElement.name() << "to" << name;
+                ct.setName(name);
                 ct.setAnonymous(true);
                 d->mComplexTypes.append(ct);
 

--- a/unittests/wsdl_document/mywsdl_document.wsdl
+++ b/unittests/wsdl_document/mywsdl_document.wsdl
@@ -57,6 +57,13 @@
           <sequence>
             <element name="TelegramHex" type="kdab:TelegramType"/>
             <element name="TelegramBase64" type="xsd:base64Binary"/>
+            <xsd:element name="repeatedName">
+              <complexType>
+                <sequence>
+                  <element name='stringparam1' type='xsd:string'/>
+                </sequence>
+              </complexType>
+            </xsd:element>
           </sequence>
         </complexType>
       </element>
@@ -137,6 +144,13 @@
           <sequence>
             <element name='employeeName' type='kdab:EmployeeName'/>
             <element name='repeatedChildren' type='kdab:TestRepeatedChildren'/>
+            <xsd:element name="repeatedName">
+              <complexType>
+                <sequence>
+                  <element name='intparam1' type='xsd:int'/>
+                </sequence>
+              </complexType>
+            </xsd:element>
           </sequence>
         </complexType>
       </element>

--- a/unittests/wsdl_document/test_wsdl_document.cpp
+++ b/unittests/wsdl_document/test_wsdl_document.cpp
@@ -467,6 +467,23 @@ private Q_SLOTS:
         params.setRepeatedChildren(children);
     }
 
+    // Test repeated names in nested complex types
+    void testRepeatedNames()
+    {
+        // Just test the generated code, two different classes should have been
+        // created for two structurally different nested complex types of the
+        // same name:
+        KDAB__TelegramResponse resp;
+        class KDAB__RepeatedName repeatedName;
+        repeatedName.setStringparam1("test1");
+        resp.setRepeatedName(repeatedName);
+
+        KDAB__EmployeeNameParams params;
+        class KDAB__RepeatedName1 repeatedName1;
+        repeatedName1.setIntparam1(1);
+        params.setRepeatedName(repeatedName1);
+    }
+
     void testSoapVersion()
     {
         // Prepare response
@@ -714,6 +731,7 @@ private:
                "David Ä Faure"
                "</n1:employeeName>"
                "<n1:repeatedChildren><n1:low>0</n1:low><n1:width>0</n1:width><n1:center>0</n1:center></n1:repeatedChildren>"
+               "<n1:repeatedName><n1:intparam1>0</n1:intparam1></n1:repeatedName>"
                "</n1:EmployeeNameParams>"
                "</soap:Body>" + xmlEnvEnd()
                + '\n'; // added by QXmlStreamWriter::writeEndDocument
@@ -1068,6 +1086,7 @@ void WsdlDocumentTest::testSendTelegram()
         QByteArray(xmlBegin) + "<n1:TelegramResponse " + xmlNamespaces + " xmlns:n1=\"http://www.kdab.com/xml/MyWsdl/\">"
         "<n1:TelegramHex>52656365697665642048656c6c6f</n1:TelegramHex>"
         "<n1:TelegramBase64>UmVjZWl2ZWQgSGVsbG8=</n1:TelegramBase64>"
+        "<n1:repeatedName><n1:stringparam1></n1:stringparam1></n1:repeatedName>"
         "</n1:TelegramResponse>";
     // m_response, however, has qualified = true (set by the generated code).
     QVERIFY(xmlBufferCompare(server->lastServerObject()->m_response.toXml(KDSoapValue::LiteralUse, msgNS), expectedResponseXml));


### PR DESCRIPTION
So far, for complexTypes nested in elements with the same name a
single C++ class has been created. This is wrong in cases where
multiple elements with the same name contain complexTypes of different
structure because different classes should be created

https://github.com/KDAB/KDSoap/issues/82
