### PR TITLE
OS X: Use @rpath in installed dylib id

### DIFF
--- a/variables.pri
+++ b/variables.pri
@@ -11,8 +11,8 @@ solaris-cc:DEFINES += SUN7
 win32-msvc*:DEFINES += _SCL_SECURE_NO_WARNINGS
 
 win32-msvc*:QMAKE_CXXFLAGS += /GR /EHsc /wd4251
-
 unix:!macx:QMAKE_LFLAGS += -Wl,-no-undefined
+macx:QMAKE_SONAME_PREFIX = @rpath
 
 CONFIG += depend_includepath
 


### PR DESCRIPTION
Currently the dylib id uses just the library file name:
```
$ otool -L /Users/.../install/lib/libkdsoap.1.dylib
/Users/.../install/lib/libkdsoap.1.dylib:
        libkdsoap.1.dylib (compatibility version 1.6.0, current version 1.6.50)
```

After this patch it is prefixed with @rpath