### PR TITLE
Add a -keep-ununsed-types argument to kdwsdl2cpp

### DIFF
--- a/kdwsdl2cpp/src/converter.cpp
+++ b/kdwsdl2cpp/src/converter.cpp
@@ -65,7 +65,9 @@ void Converter::setWSDL(const WSDL &wsdl)
 
     mTypeMap.setNSManager(&mNSManager);
 
-    cleanupUnusedTypes();
+    if (!Settings::self()->keepUnusedTypes()) {
+        cleanupUnusedTypes();
+    }
 
     // set the xsd types
     mTypeMap.addSchemaTypes(mWSDL.definitions().type().types(), Settings::self()->nameSpace());

--- a/kdwsdl2cpp/src/main.cpp
+++ b/kdwsdl2cpp/src/main.cpp
@@ -45,6 +45,7 @@ static void showHelp(const char *appName)
             "  -optional-element-type <type>\n"
             "                            use <type> as the getter return value for optional elements.\n"
             "                            <type> can be either raw-pointer or boost-optional\n"
+            " -keep-unused-types         keep the wsdl unused types to the cpp generation step\n"
             "\n", appName);
 }
 
@@ -61,6 +62,7 @@ int main(int argc, char **argv)
     QString exportMacro;
     QString nameSpace;
     Settings::OptionalElementType optionalElementType = Settings::ENone;
+    bool keepUnusedTypes = false;
 
     int arg = 1;
     while (arg < argc) {
@@ -121,6 +123,8 @@ int main(int argc, char **argv)
             } else if (optType == QLatin1String("boost-optional")) {
                 optionalElementType = Settings::EBoostOptional;
             }
+        } else if (opt == QLatin1String("-keep-unused-types")) {
+            keepUnusedTypes = true;
         } else if (!fileName) {
             fileName = argv[arg];
         } else {
@@ -145,6 +149,7 @@ int main(int argc, char **argv)
     Settings::self()->setExportDeclaration(exportMacro);
     Settings::self()->setNameSpace(nameSpace);
     Settings::self()->setOptionalElementType(optionalElementType);
+    Settings::self()->setKeepUnusedTypes(keepUnusedTypes);
     KWSDL::Compiler compiler;
 
     // so that we have an event loop, for downloads

--- a/kdwsdl2cpp/src/settings.cpp
+++ b/kdwsdl2cpp/src/settings.cpp
@@ -42,6 +42,7 @@ Settings::Settings()
     mOutputFileName = QString::fromLatin1("kwsdl_generated");
     mImpl = false;
     mServer = false;
+    mKeepUnusedTypes = false;
     mOptionalElementType = Settings::ENone;
 }
 
@@ -127,6 +128,16 @@ void Settings::setOptionalElementType(Settings::OptionalElementType optionalElem
 Settings::OptionalElementType Settings::optionalElementType() const
 {
     return mOptionalElementType;
+}
+
+void Settings::setKeepUnusedTypes(bool b)
+{
+    mKeepUnusedTypes = b;
+}
+
+bool Settings::keepUnusedTypes() const
+{
+    return mKeepUnusedTypes;
 }
 
 void Settings::setNamespaceMapping(const NSMapping &namespaceMapping)

--- a/kdwsdl2cpp/src/settings.h
+++ b/kdwsdl2cpp/src/settings.h
@@ -56,6 +56,9 @@ public:
     void setOptionalElementType(OptionalElementType optionalElementType);
     OptionalElementType optionalElementType() const;
 
+    void setKeepUnusedTypes(bool b);
+    bool keepUnusedTypes() const;
+
     // UNUSED
     void setNamespaceMapping(const NSMapping &namespaceMapping);
     NSMapping namespaceMapping() const;
@@ -84,6 +87,7 @@ private:
     bool mImpl;
     bool mServer;
     OptionalElementType mOptionalElementType;
+    bool mKeepUnusedTypes;
 };
 
 #endif

--- a/unittests/keep_unused_types/CMakeLists.txt
+++ b/unittests/keep_unused_types/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(keep_unused_types)
+
+#this is the option given to KDWSDL2CPP when generating cpp from wsdl
+set(KSWSDL2CPP_OPTION "-keep-unused-types")
+
+set(WSDL_FILES keep_unused_types.wsdl)
+set(keep_unused_types_SRCS keep_unused_types.cpp)
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${keep_unused_types_SRCS})

--- a/unittests/keep_unused_types/keep_unused_types.cpp
+++ b/unittests/keep_unused_types/keep_unused_types.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+** Copyright (C) 2010-2017 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "KDSoapClientInterface.h"
+#include "wsdl_keep_unused_types.h"
+
+#include <QtTest/QtTest>
+#include <QDebug>
+
+class KeepUnusedTypesArgumentKDWSDL2CPP: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void testKeepUnusedTypesArgument()
+    {
+        // Unused type within WSDL, if this compiles, then -keep-unused-types works since
+        // otherwise cleanupUnusedTypes function would have removed it from the cpp generation
+        TNS__UnusedElement element;
+        Q_UNUSED(element);
+    }
+};
+
+QTEST_MAIN(KeepUnusedTypesArgumentKDWSDL2CPP)
+
+#include "keep_unused_types.moc"
+

--- a/unittests/keep_unused_types/keep_unused_types.pro
+++ b/unittests/keep_unused_types/keep_unused_types.pro
@@ -1,0 +1,13 @@
+#this is the option given to KDWSDL2CPP when generating cpp from wsdl
+KDWSDL_OPTIONS = -keep-unused-types
+
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+
+QT += network xml
+SOURCES = keep_unused_types.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = keep_unused_types.wsdl

--- a/unittests/keep_unused_types/keep_unused_types.wsdl
+++ b/unittests/keep_unused_types/keep_unused_types.wsdl
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.mathertel.de/OrteLookup/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://www.mathertel.de/OrteLookup/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">A WebService retreiving the names of German cities starting with a specific string.</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://www.mathertel.de/OrteLookup/">
+      <s:element name="UnusedElement">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="prefix" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="OrteStartWith">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="prefix" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="OrteStartWithResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="OrteStartWithResult" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetPrefixedEntries">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="prefix" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetPrefixedEntriesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetPrefixedEntriesResult" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="string" nillable="true" type="s:string" />
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="OrteStartWithSoapIn">
+    <wsdl:part name="parameters" element="tns:OrteStartWith" />
+  </wsdl:message>
+  <wsdl:message name="OrteStartWithSoapOut">
+    <wsdl:part name="parameters" element="tns:OrteStartWithResponse" />
+  </wsdl:message>
+  <wsdl:message name="GetPrefixedEntriesSoapIn">
+    <wsdl:part name="parameters" element="tns:GetPrefixedEntries" />
+  </wsdl:message>
+  <wsdl:message name="GetPrefixedEntriesSoapOut">
+    <wsdl:part name="parameters" element="tns:GetPrefixedEntriesResponse" />
+  </wsdl:message>
+  <wsdl:message name="OrteStartWithHttpGetIn">
+    <wsdl:part name="prefix" type="s:string" />
+  </wsdl:message>
+  <wsdl:message name="OrteStartWithHttpGetOut">
+    <wsdl:part name="Body" element="tns:string" />
+  </wsdl:message>
+  <wsdl:message name="GetPrefixedEntriesHttpGetIn">
+    <wsdl:part name="prefix" type="s:string" />
+  </wsdl:message>
+  <wsdl:message name="GetPrefixedEntriesHttpGetOut">
+    <wsdl:part name="Body" element="tns:string" />
+  </wsdl:message>
+  <wsdl:portType name="OrteLookupSoap">
+    <wsdl:operation name="OrteStartWith">
+      <wsdl:input message="tns:OrteStartWithSoapIn" />
+      <wsdl:output message="tns:OrteStartWithSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="GetPrefixedEntries">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Return Lookup entries that start with the given prefix.</wsdl:documentation>
+      <wsdl:input message="tns:GetPrefixedEntriesSoapIn" />
+      <wsdl:output message="tns:GetPrefixedEntriesSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="OrteLookupHttpGet">
+    <wsdl:operation name="OrteStartWith">
+      <wsdl:input message="tns:OrteStartWithHttpGetIn" />
+      <wsdl:output message="tns:OrteStartWithHttpGetOut" />
+    </wsdl:operation>
+    <wsdl:operation name="GetPrefixedEntries">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Return Lookup entries that start with the given prefix.</wsdl:documentation>
+      <wsdl:input message="tns:GetPrefixedEntriesHttpGetIn" />
+      <wsdl:output message="tns:GetPrefixedEntriesHttpGetOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="OrteLookupSoap" type="tns:OrteLookupSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="OrteStartWith">
+      <soap:operation soapAction="http://www.mathertel.de/OrteLookup/OrteStartWith" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetPrefixedEntries">
+      <soap:operation soapAction="http://www.mathertel.de/OrteLookup/GetPrefixedEntries" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="OrteLookupSoap12" type="tns:OrteLookupSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="OrteStartWith">
+      <soap12:operation soapAction="http://www.mathertel.de/OrteLookup/OrteStartWith" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetPrefixedEntries">
+      <soap12:operation soapAction="http://www.mathertel.de/OrteLookup/GetPrefixedEntries" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="OrteLookupHttpGet" type="tns:OrteLookupHttpGet">
+    <http:binding verb="GET" />
+    <wsdl:operation name="OrteStartWith">
+      <http:operation location="/OrteStartWith" />
+      <wsdl:input>
+        <http:urlEncoded />
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetPrefixedEntries">
+      <http:operation location="/GetPrefixedEntries" />
+      <wsdl:input>
+        <http:urlEncoded />
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="OrteLookup">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">A WebService retreiving the names of German cities starting with a specific string.</wsdl:documentation>
+    <wsdl:port name="OrteLookupSoap" binding="tns:OrteLookupSoap">
+      <soap:address location="http://mathertel.de/AJAXEngine/S02_AJAXCoreSamples/OrteLookup.asmx" />
+    </wsdl:port>
+    <wsdl:port name="OrteLookupSoap12" binding="tns:OrteLookupSoap12">
+      <soap12:address location="http://mathertel.de/AJAXEngine/S02_AJAXCoreSamples/OrteLookup.asmx" />
+    </wsdl:port>
+    <wsdl:port name="OrteLookupHttpGet" binding="tns:OrteLookupHttpGet">
+      <http:address location="http://mathertel.de/AJAXEngine/S02_AJAXCoreSamples/OrteLookup.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
This is a follow-up to your comment from https://github.com/KDAB/KDSoap/issues/106 : 

"What might be a problem though, with this approach, is the code that strips out any data structures that aren't used by the WSDL. See Converter::cleanupUnusedTypes. If you add a command-line option for kdwsdl2cpp to keep unused types (by skipping the call to cleanupUnusedTypes when that new option --keep-unused-types is set), I can merge that in." 

