### PR TITLE
removed warning during release build

### DIFF
--- a/src/KDSoapServer/KDSoapServerObjectInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerObjectInterface.cpp
@@ -189,6 +189,7 @@ void KDSoapServerObjectInterface::writeHTTP(const QByteArray &httpReply)
 {
     const qint64 written = d->m_serverSocket->write(httpReply);
     Q_ASSERT(written == httpReply.size()); // Please report a bug if you hit this.
+    Q_UNUSED(written);
 }
 
 void KDSoapServerObjectInterface::writeXML(const QByteArray &reply, bool isFault)


### PR DESCRIPTION
During the release build the `Q_ASSERT` will be removed which leads to the warning `local variable is initialized but not referenced`.