### PR TITLE
add configurable auto-deletion of jobs

### DIFF
--- a/src/KDSoapClient/KDSoapJob.cpp
+++ b/src/KDSoapClient/KDSoapJob.cpp
@@ -29,12 +29,14 @@ class KDSoapJob::Private
 public:
     KDSoapMessage reply;
     KDSoapHeaders replyHeaders;
+    bool isAutoDelete;
 };
 
 KDSoapJob::KDSoapJob(QObject *parent)
     : QObject(parent)
     , d(new Private)
 {
+    d->isAutoDelete = true;
 }
 
 KDSoapJob::~KDSoapJob()
@@ -47,12 +49,19 @@ void KDSoapJob::start()
     QMetaObject::invokeMethod(this, "doStart", Qt::QueuedConnection);
 }
 
+void KDSoapJob::setAutoDelete(bool enable)
+{
+    d->isAutoDelete = enable;
+}
+
 void KDSoapJob::emitFinished(const KDSoapMessage &reply, const KDSoapHeaders &replyHeaders)
 {
     d->reply = reply;
     d->replyHeaders = replyHeaders;
     emit finished(this);
-    deleteLater();
+    if (d->isAutoDelete) {
+        deleteLater();
+    }
 }
 
 KDSoapMessage KDSoapJob::reply() const

--- a/src/KDSoapClient/KDSoapJob.h
+++ b/src/KDSoapClient/KDSoapJob.h
@@ -105,11 +105,17 @@ public:
      */
     void start();
 
+    /**
+     * Defines whether the job should be automatically deleted or not.
+     */
+    void setAutoDelete(bool enable);
+
 Q_SIGNALS:
     /**
      * emitted when the job is completed, i.e. the reply for the job's request
      * was received. To read the result, call reply() in the connected slot.
-     * Do not delete the job, the job will auto-delete itself.
+     * Do not delete the job, the job will auto-delete itself. This behavior
+     * can be changed with setAutoDelete().
      *
      * \param job The job instance that emitted the signal
      */


### PR DESCRIPTION
In some cases it might be necessary to access the KDSoapJob object after the work is done. Since the job deletes itself, this is currently not possible. I've implemented a new setter method to change this behavior (setAutoDelete). Maybe it could be also helpful to have a constructor parameter for this property. This would necessitate taking this parameter into all automatically generated subclasses.