### PR TITLE
don't abort the http call if authentication is not possible

### DIFF
--- a/src/KDSoapClient/KDSoapAuthentication.cpp
+++ b/src/KDSoapClient/KDSoapAuthentication.cpp
@@ -89,8 +89,5 @@ void KDSoapAuthentication::handleAuthenticationRequired(QNetworkReply *reply, QA
         authenticator->setUser(d->user);
         authenticator->setPassword(d->password);
         reply->setProperty("authAdded", true);
-    } else {
-        // protected... reply->setError(QNetworkReply::AuthenticationRequiredError, QString());
-        reply->abort();
     }
 }

--- a/unittests/builtinhttp/builtinhttp.cpp
+++ b/unittests/builtinhttp/builtinhttp.cpp
@@ -151,6 +151,7 @@ private Q_SLOTS:
         client.setAuthentication(auth);
         KDSoapMessage reply = client.call(QLatin1String("getEmployeeCountry"), countryMessage());
         QVERIFY(reply.isFault());
+        QCOMPARE(reply.childValues().child(QLatin1String("faultcode")).value().toInt(), QNetworkReply::AuthenticationRequiredError);
     }
 
     void testCorrectHttpHeader()


### PR DESCRIPTION
If no credentials is available or if the credentials are incorrect,
then the real error message is hidden behind the cancellation of the
http call. By not aborting the call, the error state will stay
QNetworkReply::AuthenticationRequiredError. This will result is KDSoap
generating a SoapFault containing the correct error message.
This way the application can detect the error and ask the user for
correct credentials.