### PR TITLE
Improve detection of soap fault in http response

### DIFF
--- a/src/KDSoapClient/KDSoapClientInterface.cpp
+++ b/src/KDSoapClient/KDSoapClientInterface.cpp
@@ -28,6 +28,7 @@
 #include "KDSoapSslHandler.h"
 #include "KDSoapReplySslHandler_p.h"
 #endif
+#include "KDSoapPendingCall_p.h"
 #include <QSslConfiguration>
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -158,7 +159,9 @@ KDSoapPendingCall KDSoapClientInterface::asyncCall(const QString &method, const 
     //qDebug() << "post()";
     QNetworkReply *reply = d->accessManager()->post(request, buffer);
     d->setupReply(reply);
-    return KDSoapPendingCall(reply, buffer);
+    KDSoapPendingCall call(reply, buffer);
+    call.d->soapVersion = d->m_version;
+    return call;
 }
 
 KDSoapMessage KDSoapClientInterface::call(const QString &method, const KDSoapMessage &message, const QString &soapAction, const KDSoapHeaders &headers)

--- a/src/KDSoapClient/KDSoapClientThread.cpp
+++ b/src/KDSoapClient/KDSoapClientThread.cpp
@@ -27,6 +27,7 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapClientInterface_p.h"
 #include "KDSoapPendingCall.h"
+#include "KDSoapPendingCall_p.h"
 #include <QNetworkRequest>
 #include <QNetworkProxy>
 #include <QBuffer>
@@ -104,6 +105,7 @@ void KDSoapThreadTask::process(QNetworkAccessManager &accessManager)
     QNetworkReply *reply = accessManager.post(request, buffer);
     m_data->m_iface->d->setupReply(reply);
     KDSoapPendingCall pendingCall(reply, buffer);
+    pendingCall.d->soapVersion = m_data->m_iface->d->m_version;
 
     KDSoapPendingCallWatcher *watcher = new KDSoapPendingCallWatcher(pendingCall, this);
     connect(watcher, SIGNAL(finished(KDSoapPendingCallWatcher*)),

--- a/src/KDSoapClient/KDSoapMessageReader_p.h
+++ b/src/KDSoapClient/KDSoapMessageReader_p.h
@@ -25,6 +25,7 @@
 #define KDSOAPMESSAGEREADER_P_H
 
 #include "KDSoapMessage.h"
+#include "KDSoapClientInterface.h"
 
 class KDSOAP_EXPORT KDSoapMessageReader
 {
@@ -37,7 +38,7 @@ public:
 
     KDSoapMessageReader();
 
-    XmlError xmlToMessage(const QByteArray &data, KDSoapMessage *pParsedMessage, QString *pMessageNamespace, KDSoapHeaders *pRequestHeaders) const;
+    XmlError xmlToMessage(const QByteArray &data, KDSoapMessage *pParsedMessage, QString *pMessageNamespace, KDSoapHeaders *pRequestHeaders, KDSoapClientInterface::SoapVersion soapVersion) const;
 };
 
 #endif

--- a/src/KDSoapClient/KDSoapPendingCall_p.h
+++ b/src/KDSoapClient/KDSoapPendingCall_p.h
@@ -28,17 +28,16 @@
 #include <QXmlStreamReader>
 #include "KDSoapMessage.h"
 #include <QPointer>
+#include "KDSoapClientInterface.h"
+#include <QNetworkReply>
 
-QT_BEGIN_NAMESPACE
-class QNetworkReply;
-QT_END_NAMESPACE
 class KDSoapValue;
 
 class KDSoapPendingCall::Private : public QSharedData
 {
 public:
     Private(QNetworkReply *r, QBuffer *b)
-        : reply(r), buffer(b), parsed(false)
+        : reply(r), buffer(b), soapVersion(KDSoapClientInterface::SOAP1_1), parsed(false)
     {
     }
     ~Private();
@@ -52,6 +51,7 @@ public:
     QBuffer *buffer;
     KDSoapMessage replyMessage;
     KDSoapHeaders replyHeaders;
+    KDSoapClientInterface::SoapVersion soapVersion;
     bool parsed;
 };
 

--- a/src/KDSoapServer/KDSoapServerSocket.cpp
+++ b/src/KDSoapServer/KDSoapServerSocket.cpp
@@ -330,7 +330,7 @@ void KDSoapServerSocket::handleRequest(const QMap<QByteArray, QByteArray> &httpH
     KDSoapMessage requestMsg;
     KDSoapHeaders requestHeaders;
     KDSoapMessageReader reader;
-    KDSoapMessageReader::XmlError err = reader.xmlToMessage(receivedData, &requestMsg, &m_messageNamespace, &requestHeaders);
+    KDSoapMessageReader::XmlError err = reader.xmlToMessage(receivedData, &requestMsg, &m_messageNamespace, &requestHeaders, KDSoapClientInterface::SOAP1_1);
     if (err == KDSoapMessageReader::PrematureEndOfDocumentError) {
         //qDebug() << "Incomplete SOAP message, wait for more data";
         // This should never happen, since we check for content-size above.

--- a/unittests/builtinhttp/builtinhttp.cpp
+++ b/unittests/builtinhttp/builtinhttp.cpp
@@ -62,10 +62,11 @@ private Q_SLOTS:
         QCOMPARE(call.returnMessage().arguments().child(QLatin1String("employeeCountry")).value().toString(), QString::fromLatin1("France"));
     }
 
-    void testFault() // HTTP error, creates fault on client side
+    void testFaultSoap11() // HTTP error, creates fault on client side
     {
         HttpServerThread server(QByteArray(), HttpServerThread::Public | HttpServerThread::Error404);
         KDSoapClientInterface client(server.endPoint(), QString::fromLatin1("urn:msg"));
+        client.setSoapVersion(KDSoapClientInterface::SOAP1_1);
         KDSoapMessage message;
         KDSoapMessage ret = client.call(QLatin1String("Method1"), message);
         QVERIFY(ret.isFault());
@@ -75,6 +76,23 @@ private Q_SLOTS:
 #else
         QCOMPARE(ret.faultAsString(), QString::fromLatin1(
                      "Fault code 203: Error downloading %1 - server replied: Not Found").arg(server.endPoint()));
+#endif
+    }
+
+    void testFaultSoap12() // HTTP error, creates fault on client side
+    {
+        HttpServerThread server(QByteArray(), HttpServerThread::Public | HttpServerThread::Error404);
+        KDSoapClientInterface client(server.endPoint(), QString::fromLatin1("urn:msg"));
+        client.setSoapVersion(KDSoapClientInterface::SOAP1_2);
+        KDSoapMessage message;
+        KDSoapMessage ret = client.call(QLatin1String("Method1"), message);
+        QVERIFY(ret.isFault());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+        QCOMPARE(ret.faultAsString(), QString::fromLatin1(
+                     "Fault 203: Error transferring %1 - server replied: Not Found").arg(server.endPoint()));
+#else
+        QCOMPARE(ret.faultAsString(), QString::fromLatin1(
+                     "Fault 203: Error downloading %1 - server replied: Not Found").arg(server.endPoint()));
 #endif
     }
 

--- a/unittests/messagereader/messagereader.cpp
+++ b/unittests/messagereader/messagereader.cpp
@@ -56,7 +56,7 @@ private Q_SLOTS:
         QString ns;
         KDSoapMessage msg;
         KDSoapHeaders headers;
-        const KDSoapMessageReader::XmlError err = reader.xmlToMessage(xmlNoWhitespace, &msg, &ns, &headers);
+        const KDSoapMessageReader::XmlError err = reader.xmlToMessage(xmlNoWhitespace, &msg, &ns, &headers, KDSoapClientInterface::SOAP1_1);
         QCOMPARE(err, KDSoapMessageReader::NoError);
         QVERIFY(!msg.isFault());
         QCOMPARE(msg.name(), QLatin1String("GetEaster"));
@@ -66,7 +66,7 @@ private Q_SLOTS:
         KDSoapMessage msg2;
         KDSoapHeaders headers2;
 
-        const KDSoapMessageReader::XmlError err2 = reader.xmlToMessage(xmlWithWhitespace, &msg2, &ns2, &headers2);
+        const KDSoapMessageReader::XmlError err2 = reader.xmlToMessage(xmlWithWhitespace, &msg2, &ns2, &headers2, KDSoapClientInterface::SOAP1_1);
         QCOMPARE(err2, KDSoapMessageReader::NoError);
         QCOMPARE(msg2.name(), QLatin1String("GetEaster"));
 
@@ -76,6 +76,42 @@ private Q_SLOTS:
             qDebug() << msg;
             qDebug() << msg2;
         }
+    }
+
+    void testFaultSoap11()
+    {
+        const QByteArray xmlMissingEnd =
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:dat=\"http://www.27seconds.com/Holidays/US/Dates/\">"
+            "<soapenv:Header/>"
+            "<soapenv:Body>";
+
+        const KDSoapMessageReader reader;
+        QString ns;
+        KDSoapMessage msg;
+        KDSoapHeaders headers;
+        const KDSoapMessageReader::XmlError err = reader.xmlToMessage(xmlMissingEnd, &msg, &ns, &headers, KDSoapClientInterface::SOAP1_1);
+        QCOMPARE(err, KDSoapMessageReader::PrematureEndOfDocumentError);
+        QVERIFY(msg.isFault());
+        QCOMPARE(msg.faultAsString(), QString::fromLatin1(
+                     "Fault code 4: XML error: [1:163] Premature end of document."));
+    }
+
+    void testFaultSoap12()
+    {
+        const QByteArray xmlMissingEnd =
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:dat=\"http://www.27seconds.com/Holidays/US/Dates/\">"
+            "<soapenv:Header/>"
+            "<soapenv:Body>";
+
+        const KDSoapMessageReader reader;
+        QString ns;
+        KDSoapMessage msg;
+        KDSoapHeaders headers;
+        const KDSoapMessageReader::XmlError err = reader.xmlToMessage(xmlMissingEnd, &msg, &ns, &headers, KDSoapClientInterface::SOAP1_2);
+        QCOMPARE(err, KDSoapMessageReader::PrematureEndOfDocumentError);
+        QVERIFY(msg.isFault());
+        QCOMPARE(msg.faultAsString(), QString::fromLatin1(
+                     "Fault 4: XML error: [1:163] Premature end of document."));
     }
 };
 


### PR DESCRIPTION
The soap 1.2 spec states that soap faults of type env:Sender should have
http status code 400 Bad request. The previous code assumed that all
soap error have status code 500 (which is true for soap 1.1). This
change tries to find a soap fault in the response data (regardless of
the http status code) and will return that if available. Else it will
fallback to the generic fault based on the response error.