### PR TITLE
kdwsdl2cpp: Added cmake option for overriding executable path

### DIFF
--- a/KDSoapMacros.cmake
+++ b/KDSoapMacros.cmake
@@ -4,7 +4,9 @@
 
 macro( KDSOAP_GENERATE_WSDL _sources )
   set(KDWSDL2CPP kdwsdl2cpp)
-  if (TARGET KDSoap::kdwsdl2cpp)
+  if (KDSOAP_KDWSDL2CPP_COMPILER)
+    set(KDWSDL2CPP ${KDSOAP_KDWSDL2CPP_COMPILER})
+  elseif (TARGET KDSoap::kdwsdl2cpp)
     set(KDWSDL2CPP KDSoap::kdwsdl2cpp)
   endif()
   set(_KSWSDL2CPP_OPTION)


### PR DESCRIPTION
Added KDSOAP_KDWSDL2CPP_COMPILER cmake variable for overriding the
selected kdwsdl2cpp executable. This is useful for cross-compiling,
where a build executable can't be executed by the host (for example,
building an Android application).