### PR TITLE
KDSoapServer: Fix for Qt without SSL compiled in

### DIFF
--- a/src/KDSoapServer/KDSoapServerSocket_p.h
+++ b/src/KDSoapServer/KDSoapServerSocket_p.h
@@ -25,10 +25,9 @@
 
 #include <QtGlobal>
 
+#include <QTcpSocket> //may define QT_NO_OPENSSL
 #ifndef QT_NO_OPENSSL
 #include <QSslSocket>
-#else
-#include <QTcpSocket>
 #endif
 
 #include <QMap>


### PR DESCRIPTION
The compilation of KDSoap was failing if Qt is build without SSL
enabled. The define QT_NO_OPENSSL is set in the
QtNetwork/qtnetwork-config.h header, which is not included before the
define is used. QTcpSocket will load header for us and was already
always included (either directly or via QSslSocket).