### PR TITLE
Added -help-on-missing option 

### DIFF
--- a/kdwsdl2cpp/src/main.cpp
+++ b/kdwsdl2cpp/src/main.cpp
@@ -53,6 +53,8 @@ static void showHelp(const char *appName)
             "  -use-local-files-only     only use local files instead of downloading them\n"
             "                            automatically. this can be used to force the correct\n"
             "                            use of the import-path option\n"
+            "  -help-on-missing          When groups or basic types could not be found, display\n"
+            "                            available types (helps with wrong namespaces)\n"
             "\n", appName);
 }
 
@@ -72,6 +74,7 @@ int main(int argc, char **argv)
     bool keepUnusedTypes = false;
     QStringList importPathList;
     bool useLocalFilesOnly = false;
+    bool helpOnMissing = false;
 
     int arg = 1;
     while (arg < argc) {
@@ -143,6 +146,8 @@ int main(int argc, char **argv)
             importPathList.append(QFile::decodeName(argv[arg]));
         } else if (opt == QLatin1String("-use-local-files-only")) {
             useLocalFilesOnly = true;
+        } else if (opt == QLatin1String("-help-on-missing")) {
+            helpOnMissing = true;
         } else if (!fileName) {
             fileName = argv[arg];
         } else {
@@ -170,6 +175,7 @@ int main(int argc, char **argv)
     Settings::self()->setKeepUnusedTypes(keepUnusedTypes);
     Settings::self()->setImportPathList(importPathList);
     Settings::self()->setUseLocalFilesOnly(useLocalFilesOnly);
+    Settings::self()->setHelpOnMissing(helpOnMissing);
     KWSDL::Compiler compiler;
 
     // so that we have an event loop, for downloads

--- a/kdwsdl2cpp/src/settings.cpp
+++ b/kdwsdl2cpp/src/settings.cpp
@@ -230,3 +230,13 @@ void Settings::setImportPathList(const QStringList &importPathList)
         mImportPathList.prepend(wsdlDirPath);
     }
 }
+
+void Settings::setHelpOnMissing(bool b)
+{
+    mHelpOnMissing = b;
+}
+
+bool Settings::helpOnMissing() const
+{
+    return mHelpOnMissing;
+}

--- a/kdwsdl2cpp/src/settings.h
+++ b/kdwsdl2cpp/src/settings.h
@@ -78,6 +78,9 @@ public:
     bool useLocalFilesOnly() const;
     void setUseLocalFilesOnly(bool useLocalFilesOnly);
 
+    bool helpOnMissing() const;
+    void setHelpOnMissing(bool b);
+
 private:
     friend class SettingsSingleton;
     Settings();
@@ -96,6 +99,7 @@ private:
     OptionalElementType mOptionalElementType;
     bool mKeepUnusedTypes;
     bool mUseLocalFilesOnly;
+    bool mHelpOnMissing;
 };
 
 #endif

--- a/kdwsdl2cpp/src/typemap.cpp
+++ b/kdwsdl2cpp/src/typemap.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <common/nsmanager.h>
+#include "settings.h"
 
 #include <QDebug>
 #include "typemap.h"
@@ -203,6 +204,12 @@ QString TypeMap::localType(const QName &typeName) const
     QList<Entry>::ConstIterator it = typeEntry(typeName);
     if (it == mTypeMap.constEnd()) {
         qDebug() << "ERROR: basic type not found:" << typeName;
+        if (Settings::self()->helpOnMissing()) {
+            QList<Entry>::ConstIterator it;
+            for (it = mTypeMap.constBegin(); it != mTypeMap.constEnd(); ++it) {
+                qDebug() << (*it).nameSpace << " :: " << (*it).typeName;
+            }
+        }
         return QString();
     }
     if (!(*it).builtinType) {
@@ -304,6 +311,12 @@ QString TypeMap::localTypeForElement(const QName &elementName) const
     }
 
     qDebug() << "TypeMap::localTypeForElement: unknown type" << elementName;
+    if (Settings::self()->helpOnMissing()) {
+        QList<Entry>::ConstIterator jt;
+        for (jt = mElementMap.constBegin(); jt != mElementMap.constEnd(); ++jt) {
+            qDebug() << (*jt).nameSpace << " :: " << (*jt).typeName;
+        }
+    }
     return QString();
 }
 
@@ -315,6 +328,12 @@ QName TypeMap::baseTypeForElement(const QName &elementName) const
     }
 
     qDebug() << "TypeMap::typeForElement: unknown type" << elementName;
+    if (Settings::self()->helpOnMissing()) {
+        QList<Entry>::ConstIterator jt;
+        for (jt = mElementMap.constBegin(); jt != mElementMap.constEnd(); ++jt) {
+            qDebug() << (*jt).nameSpace << " :: " << (*jt).typeName;
+        }
+    }
     return QName();
 }
 
@@ -420,6 +439,12 @@ void TypeMap::addSchemaTypes(const XSD::Types &types, const QString &ns)
         QList<Entry>::ConstIterator it = typeEntry(type);
         if (it == mTypeMap.constEnd()) {
             qDebug() << "ERROR: basic type not found:" << type;
+            if (Settings::self()->helpOnMissing()) {
+                QList<Entry>::ConstIterator jt;
+                for (jt = mTypeMap.constBegin(); jt != mTypeMap.constEnd(); ++jt) {
+                    qDebug() << (*jt).nameSpace << " :: " << (*jt).typeName;
+                }
+            }
             Q_ASSERT(0);
             continue;
         }


### PR DESCRIPTION
Added -help-on-missing option  to kdwsdl2cpp to display extra help on missing types. This what
we talked about in issue #136 before I found out that KDSoap generates server and client stubs anyway when set to generate server stubs.
