### PR TITLE
Update KDSoapServerSocket_p.h

### DIFF
--- a/src/KDSoapServer/KDSoapServerSocket_p.h
+++ b/src/KDSoapServer/KDSoapServerSocket_p.h
@@ -24,6 +24,7 @@
 #define KDSOAPSERVERSOCKET_P_H
 
 #include <QtGlobal>
+#include <qtnetwork-config.h>
 
 #include <QTcpSocket> //may define QT_NO_OPENSSL
 #ifndef QT_NO_OPENSSL


### PR DESCRIPTION
On my platform, using Qt 5.9.6, QT_NO_OPENSSL is defined in qtnetwork-config.h
In KDSoapServerSocket_p.h line 29, QT_NO_OPENSSL is not defined which leads to the inclusion of QSslSocket.h.
QSslSocket.h includes qtnetwork-config.h indirectly, now QT_NO_OPENSSL is defined, KDSoapServerSocket does not inherit from the already included QSslSocket but from QTcpSocket which was not included ...

qtnetwork-config.h must be included before using QT_NO_OPENSSL.