### PR TITLE
WS-UsernameToken

### DIFF
--- a/doc/CHANGES_1_8.txt
+++ b/doc/CHANGES_1_8.txt
@@ -12,6 +12,7 @@ Client-side:
 * Fix error code when authentication failed
 * Autodeletion of jobs is now configurable (github pull #125)
 * Add error details in faultAsString() - and the generated lastError() - coming from the SOAP 1.2 detail element.
+* Add support for WS-UsernameToken, see KDSoapAuthentication
 
 Server-side:
 ============

--- a/src/KDSoapClient/KDSoapAuthentication.cpp
+++ b/src/KDSoapClient/KDSoapAuthentication.cpp
@@ -139,12 +139,8 @@ bool KDSoapAuthentication::hasWSUsernameTokenHeader() const
     return hasAuth() && d->useWSUsernameToken;
 }
 
-void KDSoapAuthentication::writeWSUsernameTokenHeader(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const
+void KDSoapAuthentication::writeWSUsernameTokenHeader(QXmlStreamWriter &writer) const
 {
-    Q_UNUSED(namespacePrefixes);
-    Q_UNUSED(messageNamespace);
-    Q_UNUSED(forceQualified);
-
     if (!hasAuth()) {
         return;
     }

--- a/src/KDSoapClient/KDSoapAuthentication.cpp
+++ b/src/KDSoapClient/KDSoapAuthentication.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
 ** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Casper Meijn  <casper@meijn.net>
 ** All rights reserved.
 **
 ** This file is part of the KD Soap library.
@@ -21,15 +22,26 @@
 **
 **********************************************************************/
 #include "KDSoapAuthentication.h"
-#include <QNetworkReply>
-#include <QDebug>
 #include <QAuthenticator>
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDebug>
+#include <QNetworkReply>
+#include "KDSoapNamespacePrefixes_p.h"
+#include "KDSoapNamespaceManager.h"
 
 class KDSoapAuthentication::Private
 {
 public:
+    Private() :
+        useWSUsernameToken(false)
+    {}
+
     QString user;
     QString password;
+    bool useWSUsernameToken;
+    QDateTime overrideWSUsernameCreatedTime;
+    QByteArray overrideWSUsernameNonce;
 };
 
 KDSoapAuthentication::KDSoapAuthentication()
@@ -64,6 +76,21 @@ void KDSoapAuthentication::setPassword(const QString &password)
     d->password = password;
 }
 
+void KDSoapAuthentication::setUseWSUsernameToken(bool useWSUsernameToken)
+{
+    d->useWSUsernameToken = useWSUsernameToken;
+}
+
+void KDSoapAuthentication::setOverrideWSUsernameCreatedTime(QDateTime overrideWSUsernameCreatedTime)
+{
+    d->overrideWSUsernameCreatedTime = overrideWSUsernameCreatedTime;
+}
+
+void KDSoapAuthentication::setOverrideWSUsernameNonce(QByteArray overrideWSUsernameNonce)
+{
+    d->overrideWSUsernameNonce = overrideWSUsernameNonce;
+}
+
 QString KDSoapAuthentication::user() const
 {
     return d->user;
@@ -72,6 +99,21 @@ QString KDSoapAuthentication::user() const
 QString KDSoapAuthentication::password() const
 {
     return d->password;
+}
+
+bool KDSoapAuthentication::useWSUsernameToken() const
+{
+    return d->useWSUsernameToken;
+}
+
+QDateTime KDSoapAuthentication::overrideWSUsernameCreatedTime() const
+{
+    return d->overrideWSUsernameCreatedTime;
+}
+
+QByteArray KDSoapAuthentication::overrideWSUsernameNonce() const
+{
+    return d->overrideWSUsernameNonce;
 }
 
 bool KDSoapAuthentication::hasAuth() const
@@ -90,4 +132,58 @@ void KDSoapAuthentication::handleAuthenticationRequired(QNetworkReply *reply, QA
         authenticator->setPassword(d->password);
         reply->setProperty("authAdded", true);
     }
+}
+
+bool KDSoapAuthentication::hasWSUsernameTokenHeader() const
+{
+    return hasAuth() && d->useWSUsernameToken;
+}
+
+void KDSoapAuthentication::writeWSUsernameTokenHeader(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const
+{
+    Q_UNUSED(namespacePrefixes);
+    Q_UNUSED(messageNamespace);
+    Q_UNUSED(forceQualified);
+
+    if (!hasAuth()) {
+        return;
+    }
+
+    const QString securityExtentionNS = KDSoapNamespaceManager::soapSecurityExtention();
+    const QString securityUtilityNS = KDSoapNamespaceManager::soapSecurityUtility();
+
+    QByteArray nonce = "kdsoap" + QByteArray::number(qrand());
+    if (!d->overrideWSUsernameNonce.isEmpty()) {
+        nonce = d->overrideWSUsernameNonce;
+    }
+    QDateTime time = QDateTime::currentDateTimeUtc();
+    if (d->overrideWSUsernameCreatedTime.isValid()) {
+        time = d->overrideWSUsernameCreatedTime;
+    }
+    QString timestamp = time.toString(QLatin1String("yyyy-MM-ddTHH:mm:ssZ"));
+    QByteArray passwordConcat = nonce + timestamp.toUtf8() + d->password.toUtf8();
+    QByteArray passwordHash = QCryptographicHash::hash(passwordConcat, QCryptographicHash::Sha1);
+
+    writer.writeStartElement(securityExtentionNS, QLatin1String("Security"));
+    writer.writeStartElement(securityExtentionNS, QLatin1String("UsernameToken"));
+
+    writer.writeStartElement(securityExtentionNS, QLatin1String("Nonce"));
+    writer.writeCharacters(QString::fromLatin1(nonce.toBase64().constData()));
+    writer.writeEndElement();
+
+    writer.writeStartElement(securityUtilityNS, QLatin1String("Created"));
+    writer.writeCharacters(timestamp);
+    writer.writeEndElement();
+
+    writer.writeStartElement(securityExtentionNS, QLatin1String("Password"));
+    writer.writeAttribute(QLatin1String("Type"), QLatin1String("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest"));
+    writer.writeCharacters(QString::fromLatin1(passwordHash.toBase64().constData()));
+    writer.writeEndElement();
+
+    writer.writeStartElement(securityExtentionNS, QLatin1String("Username"));
+    writer.writeCharacters(d->user);
+    writer.writeEndElement();
+
+    writer.writeEndElement();
+    writer.writeEndElement();
 }

--- a/src/KDSoapClient/KDSoapAuthentication.h
+++ b/src/KDSoapClient/KDSoapAuthentication.h
@@ -82,6 +82,7 @@ public:
     /**
      * Sets whether WS-UsernameToken is used for authentication. When
      * set, the WS-UsernameToken headers are included in each request.
+     * See https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0.pdf
      * \since 1.8
      */
     void setUseWSUsernameToken(bool useWSUsernameToken);
@@ -132,9 +133,15 @@ private:
      */
     void handleAuthenticationRequired(QNetworkReply *reply, QAuthenticator *authenticator);
 
+    /**
+     * \internal
+     */
     bool hasWSUsernameTokenHeader() const;
 
-    void writeWSUsernameTokenHeader(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const;
+    /**
+     * \internal
+     */
+    void writeWSUsernameTokenHeader(QXmlStreamWriter &writer) const;
 
 private:
     class Private;

--- a/src/KDSoapClient/KDSoapAuthentication.h
+++ b/src/KDSoapClient/KDSoapAuthentication.h
@@ -1,5 +1,6 @@
 /****************************************************************************
 ** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Casper Meijn  <casper@meijn.net>
 ** All rights reserved.
 **
 ** This file is part of the KD Soap library.
@@ -27,8 +28,11 @@
 #include <QtCore/QUrl>
 QT_BEGIN_NAMESPACE
 class QAuthenticator;
+class QDateTime;
 class QNetworkReply;
+class QXmlStreamWriter;
 QT_END_NAMESPACE
+class KDSoapNamespacePrefixes;
 
 /**
  * KDSoapAuthentication provides an authentication object.
@@ -40,6 +44,7 @@ QT_END_NAMESPACE
 class KDSOAP_EXPORT KDSoapAuthentication
 {
 public:
+    friend class KDSoapMessageWriter;
     friend class KDSoapClientInterfacePrivate;
     friend class KDSoapThreadTask;
 
@@ -75,6 +80,42 @@ public:
     QString password() const;
 
     /**
+     * Sets whether WS-UsernameToken is used for authentication. When
+     * set, the WS-UsernameToken headers are included in each request.
+     * \since 1.8
+     */
+    void setUseWSUsernameToken(bool useWSUsernameToken);
+    /**
+     * \since 1.8
+     * \return whether WS-UsernameToken is used for authentication
+     */
+    bool useWSUsernameToken() const;
+
+    /**
+     * Sets the created time used during WS-UsernameToken authentication
+     * This is useful for devices with an incorrect time and during testing
+     * \since 1.8
+     */
+    void setOverrideWSUsernameCreatedTime(QDateTime overrideWSUsernameCreatedTime);
+    /**
+     * \since 1.8
+     * \return the created time used during WS-UsernameToken authentication
+     */
+    QDateTime overrideWSUsernameCreatedTime() const;
+
+    /**
+     * Sets the nonce used during WS-UsernameToken authentication
+     * This is useful during testing
+     * \since 1.8
+     */
+    void setOverrideWSUsernameNonce(QByteArray overrideWSUsernameNonce);
+    /**
+     * \since 1.8
+     * \return the created time used during WS-UsernameToken authentication
+     */
+    QByteArray overrideWSUsernameNonce() const;
+
+    /**
      * \return \c true if authentication was defined, or
      * \c false if this object is only a default-constructed KDSoapAuthentication().
      */
@@ -90,6 +131,10 @@ private:
      * \internal
      */
     void handleAuthenticationRequired(QNetworkReply *reply, QAuthenticator *authenticator);
+
+    bool hasWSUsernameTokenHeader() const;
+
+    void writeWSUsernameTokenHeader(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const;
 
 private:
     class Private;

--- a/src/KDSoapClient/KDSoapAuthentication.h
+++ b/src/KDSoapClient/KDSoapAuthentication.h
@@ -40,6 +40,9 @@ QT_END_NAMESPACE
 class KDSOAP_EXPORT KDSoapAuthentication
 {
 public:
+    friend class KDSoapClientInterfacePrivate;
+    friend class KDSoapThreadTask;
+
     /**
      * Constructs an empty authentication object.
      */
@@ -82,6 +85,7 @@ public:
      */
     KDSoapAuthentication &operator=(const KDSoapAuthentication &other);
 
+private:
     /**
      * \internal
      */

--- a/src/KDSoapClient/KDSoapClientInterface.cpp
+++ b/src/KDSoapClient/KDSoapClientInterface.cpp
@@ -147,7 +147,7 @@ QBuffer *KDSoapClientInterfacePrivate::prepareRequestBuffer(const QString &metho
     KDSoapMessageWriter msgWriter;
     msgWriter.setMessageNamespace(m_messageNamespace);
     msgWriter.setVersion(m_version);
-    const QByteArray data = msgWriter.messageToXml(message, (m_style == KDSoapClientInterface::RPCStyle) ? method : QString(), headers, m_persistentHeaders);
+    const QByteArray data = msgWriter.messageToXml(message, (m_style == KDSoapClientInterface::RPCStyle) ? method : QString(), headers, m_persistentHeaders, m_authentication);
     QBuffer *buffer = new QBuffer;
     buffer->setData(data);
     buffer->open(QIODevice::ReadOnly);

--- a/src/KDSoapClient/KDSoapMessageWriter.cpp
+++ b/src/KDSoapClient/KDSoapMessageWriter.cpp
@@ -44,7 +44,8 @@ void KDSoapMessageWriter::setMessageNamespace(const QString &ns)
 }
 
 QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage &message, const QString &method,
-        const KDSoapHeaders &headers, const QMap<QString, KDSoapMessage> &persistentHeaders) const
+        const KDSoapHeaders &headers, const QMap<QString, KDSoapMessage> &persistentHeaders,
+        const KDSoapAuthentication &authentication) const
 {
     QByteArray data;
     QXmlStreamWriter writer(&data);
@@ -73,7 +74,7 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage &message, const
         messageNamespace = message.namespaceUri();
     }
 
-    if (!headers.isEmpty() || !persistentHeaders.isEmpty() || message.hasMessageAddressingProperties()) {
+    if (!headers.isEmpty() || !persistentHeaders.isEmpty() || message.hasMessageAddressingProperties() || authentication.hasWSUsernameTokenHeader()) {
         // This writeNamespace line adds the xmlns:n1 to <Envelope>, which looks ugly and unusual (and breaks all unittests)
         // However it's the best solution in case of headers, otherwise we get n1 in the header and n2 in the body,
         // and xsi:type attributes that refer to n1, which isn't defined in the body...
@@ -87,6 +88,9 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage &message, const
         }
         if (message.hasMessageAddressingProperties()) {
             message.messageAddressingProperties().writeMessageAddressingProperties(namespacePrefixes, writer, messageNamespace, true);
+        }
+        if (authentication.hasWSUsernameTokenHeader()) {
+            authentication.writeWSUsernameTokenHeader(namespacePrefixes, writer, messageNamespace, true);
         }
         writer.writeEndElement(); // Header
     } else {

--- a/src/KDSoapClient/KDSoapMessageWriter.cpp
+++ b/src/KDSoapClient/KDSoapMessageWriter.cpp
@@ -90,7 +90,7 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage &message, const
             message.messageAddressingProperties().writeMessageAddressingProperties(namespacePrefixes, writer, messageNamespace, true);
         }
         if (authentication.hasWSUsernameTokenHeader()) {
-            authentication.writeWSUsernameTokenHeader(namespacePrefixes, writer, messageNamespace, true);
+            authentication.writeWSUsernameTokenHeader(writer);
         }
         writer.writeEndElement(); // Header
     } else {

--- a/src/KDSoapClient/KDSoapMessageWriter_p.h
+++ b/src/KDSoapClient/KDSoapMessageWriter_p.h
@@ -24,6 +24,7 @@
 #define KDSOAPMESSAGEWRITER_P_H
 
 #include "KDSoapMessage.h"
+#include "KDSoapAuthentication.h"
 #include "KDSoapClientInterface.h"
 #include <QtCore/QXmlStreamWriter>
 #include <QtCore/QByteArray>
@@ -49,7 +50,8 @@ public:
 
     QByteArray messageToXml(const KDSoapMessage &message, const QString &method /*empty in document style*/,
                             const KDSoapHeaders &headers,
-                            const QMap<QString, KDSoapMessage> &persistentHeaders) const;
+                            const QMap<QString, KDSoapMessage> &persistentHeaders,
+                            const KDSoapAuthentication &authentication = KDSoapAuthentication()) const;
 
 private:
     QString m_messageNamespace;

--- a/src/KDSoapClient/KDSoapNamespaceManager.cpp
+++ b/src/KDSoapClient/KDSoapNamespaceManager.cpp
@@ -70,3 +70,13 @@ QString KDSoapNamespaceManager::soapMessageAddressing()
 {
     return QString::fromLatin1("http://www.w3.org/2005/08/addressing");
 }
+
+QString KDSoapNamespaceManager::soapSecurityExtention()
+{
+    return QString::fromLatin1("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd");
+}
+
+QString KDSoapNamespaceManager::soapSecurityUtility()
+{
+    return QString::fromLatin1("http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
+}

--- a/src/KDSoapClient/KDSoapNamespaceManager.h
+++ b/src/KDSoapClient/KDSoapNamespaceManager.h
@@ -41,6 +41,8 @@ public:
     static QString soapEncoding();
     static QString soapEncoding200305();
     static QString soapMessageAddressing();
+    static QString soapSecurityExtention();
+    static QString soapSecurityUtility();
 
 private: // TODO instantiate to handle custom namespaces per clientinterface
     KDSoapNamespaceManager();

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(encapsecurity)
 add_subdirectory(prefix_wsdl)
 add_subdirectory(vidyo)
 add_subdirectory(ws_addressing_support)
+add_subdirectory(ws_usernametoken_support)
 add_subdirectory(empty_element_wsdl)
 
 # These need internet access

--- a/unittests/dwservice_12_wsdl/test_dwservice_12_wsdl.cpp
+++ b/unittests/dwservice_12_wsdl/test_dwservice_12_wsdl.cpp
@@ -24,7 +24,6 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
-#include "KDSoapAuthentication.h"
 #include "KDDateTime.h"
 #include "wsdl_DWService_12.h"
 #include "httpserver_p.h"

--- a/unittests/dwservice_combined_wsdl/test_dwservice_combined_wsdl.cpp
+++ b/unittests/dwservice_combined_wsdl/test_dwservice_combined_wsdl.cpp
@@ -24,7 +24,6 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
-#include "KDSoapAuthentication.h"
 #include "KDDateTime.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/dwservice_wsdl/test_dwservice_wsdl.cpp
+++ b/unittests/dwservice_wsdl/test_dwservice_wsdl.cpp
@@ -24,7 +24,6 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
-#include "KDSoapAuthentication.h"
 #include "KDDateTime.h"
 #include "wsdl_DWService.h"
 #include "httpserver_p.h"

--- a/unittests/encapsecurity/test_encapsecurity.cpp
+++ b/unittests/encapsecurity/test_encapsecurity.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_authstateless.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/groupwise_wsdl/test_groupwise_wsdl.cpp
+++ b/unittests/groupwise_wsdl/test_groupwise_wsdl.cpp
@@ -24,7 +24,6 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
-#include "KDSoapAuthentication.h"
 #include "KDDateTime.h"
 #include "wsdl_groupwise.h"
 #include "httpserver_p.h"

--- a/unittests/import_definition/test_import_definition.cpp
+++ b/unittests/import_definition/test_import_definition.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_import_definition.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/literal_true_false/test_literal.cpp
+++ b/unittests/literal_true_false/test_literal.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_literal.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/msexchange_noservice_wsdl/msexchange_noservice_wsdl.cpp
+++ b/unittests/msexchange_noservice_wsdl/msexchange_noservice_wsdl.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_Services_noservice.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/msexchange_wsdl/msexchange_wsdl.cpp
+++ b/unittests/msexchange_wsdl/msexchange_wsdl.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_Services.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/salesforce_wsdl/salesforce_wsdl.cpp
+++ b/unittests/salesforce_wsdl/salesforce_wsdl.cpp
@@ -24,7 +24,6 @@
 #include "KDSoapClientInterface.h"
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_salesforce-partner.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -45,7 +45,8 @@ SUBDIRS = \
   date_example \
   dv_terminalauth \
   test_calc \
-  ws_addressing_support
+  ws_addressing_support \
+  ws_usernametoken_support
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl

--- a/unittests/unqualified_formdefault/test_unqualified.cpp
+++ b/unittests/unqualified_formdefault/test_unqualified.cpp
@@ -25,7 +25,6 @@
 #include "KDSoapMessage.h"
 #include "KDSoapValue.h"
 #include "KDSoapPendingCallWatcher.h"
-#include "KDSoapAuthentication.h"
 #include "wsdl_unqualified.h"
 #include "httpserver_p.h"
 #include <QtTest/QtTest>

--- a/unittests/webcalls_wsdl/webcalls_wsdl.cpp
+++ b/unittests/webcalls_wsdl/webcalls_wsdl.cpp
@@ -22,8 +22,6 @@
 **********************************************************************/
 
 #include "KDSoapClientInterface.h"
-//#include "KDSoapMessage.h"
-//#include "KDSoapValue.h"
 #include "wsdl_soapresponder.h"
 #include "wsdl_holidays.h"
 #include "wsdl_BFGlobalService.h"

--- a/unittests/ws_usernametoken_support/CMakeLists.txt
+++ b/unittests/ws_usernametoken_support/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(ws_usernametoken_support)
+
+set(WSDL_FILES wsusernametoken.wsdl)
+set(ws_usernametoken_support_SRCS wsusernametokentest.cpp )
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${ws_usernametoken_support_SRCS} )

--- a/unittests/ws_usernametoken_support/ws_usernametoken_support.pro
+++ b/unittests/ws_usernametoken_support/ws_usernametoken_support.pro
@@ -1,0 +1,9 @@
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += network xml
+SOURCES = wsusernametokentest.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = wsusernametoken.wsdl

--- a/unittests/ws_usernametoken_support/wsusernametoken.wsdl
+++ b/unittests/ws_usernametoken_support/wsusernametoken.wsdl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="HelloService"
+   targetNamespace="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns="http://schemas.xmlsoap.org/wsdl/"
+   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+   xmlns:tns="http://www.ecerami.com/wsdl/HelloService.wsdl"
+   xmlns:wsa="http://www.w3.org/2005/08/addressing"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+   <message name="SayHelloRequest">
+      <part name="msg" type="xsd:string"/>
+   </message>
+   <message name="SayHelloResponse">
+      <part name="reply" type="xsd:string"/>
+   </message>
+
+   <portType name="Hello_PortType">
+      <operation name="sayHello">
+         <input message="tns:SayHelloRequest" wsaw:Action="http://localhost:8081/hello"/>
+         <output message="tns:SayHelloResponse" wsaw:Action="http://localhost:8081/hello"/>
+      </operation>
+   </portType>
+
+   <binding name="Hello_Binding" type="tns:Hello_PortType">
+      <wsaw:UsingAddressing wsdl:required="true" /> <!--NEED TO BE TAKEN INTO ACCOUNT -->
+      <soap:binding style="document"
+         transport="http://schemas.xmlsoap.org/soap/http"/>
+      <operation name="sayHello" style="document">
+         <soap:operation soapAction="sayHello"/>
+         <input wsaw:Action="http://localhost:8081/hello">
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </input>
+         <output>
+            <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/>
+         </output>
+      </operation>
+</binding>
+
+   <service name="Hello_Service">
+      <documentation>WSDL File for HelloService</documentation>
+      <port binding="tns:Hello_Binding" name="Hello_Port">
+         <soap:address location="http://localhost:8081/hello" />
+
+         <wsa:EndpointReference
+             xmlns:example="http://example.com/namespace"
+             xmlns:wsdli="http://www.w3.org/2006/01/wsdl-instance"
+             wsdli:wsdlLocation="http://example.com/location">
+
+             <wsa:Address>http://localhost:8081/hello</wsa:Address>
+             <wsa:Metadata>
+                <wsam:InterfaceName>example:Inventory</wsam:InterfaceName>
+             </wsa:Metadata>
+             <wsa:ReferenceParameters>
+               <example:AccountCode>123456789</example:AccountCode>
+               <example:DiscountId>ABCDEFG</example:DiscountId>
+             </wsa:ReferenceParameters>
+         </wsa:EndpointReference>
+
+      </port>
+   </service>
+</definitions>

--- a/unittests/ws_usernametoken_support/wsusernametokentest.cpp
+++ b/unittests/ws_usernametoken_support/wsusernametokentest.cpp
@@ -1,0 +1,101 @@
+/****************************************************************************
+** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Casper Meijn  <casper@meijn.net>
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "httpserver_p.h"
+
+#include <QtTest/QtTest>
+#include <QObject>
+
+#include "KDSoapNamespaceManager.h"
+#include "KDSoapAuthentication.h"
+#include "wsdl_wsusernametoken.h"
+
+using namespace KDSoapUnitTestHelpers;
+
+class WSUsernameTokenTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void shouldWriteAProperSoapMessageWithRightUsernameToken()
+    {
+        // GIVEN
+        HttpServerThread server(emptyResponse(), HttpServerThread::Public);
+        KDSoapClientInterface client(server.endPoint(), "http://www.ecerami.com/wsdl/HelloService");
+
+        KDSoapAuthentication auth;
+        auth.setUser("admin");
+        auth.setPassword("userpassword");
+        auth.setUseWSUsernameToken(true);
+
+        // Override the nonce and timestamp to make the test output consistent.
+        auth.setOverrideWSUsernameNonce(QByteArray::fromBase64("LKqI6G/AikKCQrN0zqZFlg=="));
+        auth.setOverrideWSUsernameCreatedTime(QDateTime(QDate(2010, 9, 16), QTime(7, 50, 45), Qt::UTC));//2010-09-16T07:50:45Z
+
+        client.setAuthentication(auth);
+
+        // make a request
+        KDSoapMessage message;
+        const QString action = QString::fromLatin1("sayHello");
+        message.setUse(KDSoapMessage::EncodedUse);
+        message.addArgument(QString::fromLatin1("msg"), QVariant::fromValue(QString("HelloContentMessage")), KDSoapNamespaceManager::xmlSchema2001(), QString::fromLatin1("string"));
+        message.setNamespaceUri(QString::fromLatin1("http://www.ecerami.com/wsdl/HelloService.wsdl"));
+
+        // WHEN
+        KDSoapMessage reply = client.call(QLatin1String("sayHello"), message, action);
+
+        // THEN
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage()));
+    }
+
+private:
+    static QByteArray expectedSoapMessage()
+    {
+        return QByteArray(xmlEnvBegin11()) +
+                " xmlns:n1=\"http://www.ecerami.com/wsdl/HelloService.wsdl\">"
+                "  <soap:Header> "
+                "    <n2:Security xmlns:n2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"> "
+                "      <n2:UsernameToken> "
+                "        <n2:Nonce>LKqI6G/AikKCQrN0zqZFlg==</n2:Nonce> "
+                "        <n3:Created xmlns:n3=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">2010-09-16T07:50:45Z</n3:Created> "
+                "        <n2:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest\">tuOSpGlFlIXsozq4HFNeeGeFLEI=</n2:Password> "
+                "        <n2:Username>admin</n2:Username> "
+                "      </n2:UsernameToken> "
+                "    </n2:Security> "
+                "  </soap:Header> "
+                "  <soap:Body> "
+                "    <n1:sayHello><msg xsi:type=\"xsd:string\">HelloContentMessage</msg></n1:sayHello> "
+                "  </soap:Body> " + xmlEnvEnd();
+    }
+
+    static QByteArray emptyResponse()
+    {
+        return QByteArray(xmlEnvBegin11()) + "><soap:Body/>";
+    }
+};
+
+QTEST_MAIN(WSUsernameTokenTest)
+
+#include "wsusernametokentest.moc"


### PR DESCRIPTION
This pull request has some cleanup commits and adds support for WS-UsernameToken. WS-UsernameToken is enabled by setting KDSoapAuthentication::useWSUsernameToken, then a fresh authentication header is added to all requests.

For the unit-test I added KDSoapAuthentication::setOverrideWSUsernameCreatedTime and KDSoapAuthentication::setOverrideWSUsernameNonce to make it reproducible. Do you know a better way of handling this? I think that this way is OK, but it doesn't feel right.

Is it possible to make this feature detectable from CMake, so that my application can fallback to its own implementation for older versions of KDSoap? I am thinking of a CMake variable or version number bump. I don't know what the standard way of doing this is.