### PR TITLE
Re-enable support for CMake older than 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #  Build the test harness.
 #  Default=false
 #
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8.7)
 cmake_policy(SET CMP0020 NEW)
 
 if("${CMAKE_INSTALL_PREFIX}" STREQUAL "")
@@ -28,7 +28,13 @@ option(
   OFF
 )
 
-set(CMAKE_CXX_STANDARD 11)
+if(CMAKE_VERSION VERSION_LESS "3.1")
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif ()
+else()
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_MODULE_PATH}")
 


### PR DESCRIPTION
Commit a387ff19da8166735dd69edbec1478754f8afe41 enables C++11 support, but by doing so also bumps the required CMake version to 3.1. This prevents building of KDSoap on CentOS/RHEL 7, which is still using CMake 2.8.12.

This PR adds a fall-back way of enabling C++11 for gcc with CMake < 3.1, and relaxes the required CMake version.