### PR TITLE
Support qname

### DIFF
--- a/doc/CHANGES_1_8.txt
+++ b/doc/CHANGES_1_8.txt
@@ -30,6 +30,14 @@ Server-side:
 
 WSDL parser / code generator changes, applying to both client and server side:
 ================================================================
+* Source incompatible change: all deserialize() functions now require a KDSoapValue instead of a 
+    QVariant. If you use a deserialize(QVariant) function, you need to port your code to use 
+    KDSoapValue::setValue(QVariant) before deserialize()
+* Source incompatible change: all serialize() functions now return a KDSoapValue instead of a 
+    QVariant. If you use a QVariant serialize() function, you need to port your code to use 
+    QVariant KDSoapValue::value() after serialize()
+* Source incompatible change: xs:QName is now respresented by KDQName instead of QString, which 
+    allows the namespace to be extracted. The old behaviour is available via KDQName::qname().
 * Fix double-handling of empty elements
 * Fix fault elements being generated in the wrong namespace, must be SOAP-ENV:Fault (github issue #81).
 * Added import-path argument for setting the local path to get (otherwise downloaded) files from.
@@ -41,3 +49,5 @@ WSDL parser / code generator changes, applying to both client and server side:
 * Added "hasValueFor{MemberName}()" accessor function, for optional elements
 * Generated services now include soapVersion() and endpoint() accessors to match the setSoapVersion(...) and setEndpoint(...) mutators
 * Added support for generating messages for WSDL files without services or bindings
+* KDSoapValue now stores the namespace declarations during parsing of a message and writes 
+    namespace declarations during sending of a message

--- a/kdwsdl2cpp/src/converter_clientstub.cpp
+++ b/kdwsdl2cpp/src/converter_clientstub.cpp
@@ -588,13 +588,13 @@ KODE::Code Converter::deserializeRetVal(const KWSDL::Part &part, const QString &
     const bool isComplex = mTypeMap.isComplexType(part.type(), part.element());
     const bool isPolymorphic = mTypeMap.isPolymorphic(part.type(), part.element());
     if (isBuiltin) {
-        code += varName + QLatin1String(" = ") + mTypeMap.deserializeBuiltin(part.type(), part.element(), replyMsgName + QLatin1String(".value()"), qtRetType) + QLatin1String(";") + COMMENT;
+        code += varName + QLatin1String(" = ") + mTypeMap.deserializeBuiltin(part.type(), part.element(), replyMsgName, qtRetType) + QLatin1String(";") + COMMENT;
     } else if (isComplex) {
         const QString op = isPolymorphic ? "->" : ".";
         code += varName + op + QLatin1String("deserialize(") + replyMsgName + QLatin1String(");") + COMMENT;
     } else {
         // testcase: MyWsdlDocument::sendTelegram
-        code += varName + QLatin1String(".deserialize(") + replyMsgName + QLatin1String(".value());") + COMMENT;
+        code += varName + QLatin1String(".deserialize(") + replyMsgName + QLatin1String(");") + COMMENT;
     }
     return code;
 }
@@ -799,10 +799,6 @@ void Converter::convertClientOutputMessage(const Operation &operation,
                     partNames << value + QLatin1String(".value().value<") + partType + QLatin1String(">()");
                 } else {
                     slotCode += partType + QLatin1String(" ret;"); // local var. TODO ret1/ret2 etc. if more than one.
-                    const bool isComplex = mTypeMap.isComplexType(part.type(), part.element());
-                    if (!isComplex) {
-                        value += QLatin1String(".value()");
-                    }
                     slotCode += QLatin1String("ret.deserialize(") + value + QLatin1String(");") + COMMENT;
                     partNames << QLatin1String("ret");
                 }

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -389,11 +389,11 @@ KODE::Code Converter::demarshalVarHelper(const QName &type, const QName &element
     if (mTypeMap.isTypeAny(type)) {
         code += variableName + QLatin1String(" = ") + soapValueVarName + QLatin1String(";") + COMMENT;
     } else if (mTypeMap.isBuiltinType(type, elementType)) {
-        code += variableName + QLatin1String(" = ") + mTypeMap.deserializeBuiltin(type, elementType, soapValueVarName + QLatin1String(".value()"), qtTypeName) + QLatin1String(";") + COMMENT;
+        code += variableName + QLatin1String(" = ") + mTypeMap.deserializeBuiltin(type, elementType, soapValueVarName, qtTypeName) + QLatin1String(";") + COMMENT;
     } else if (mTypeMap.isComplexType(type, elementType)) {
         code += variableName + QLatin1String(".deserialize(") + soapValueVarName + QLatin1String(");") + COMMENT;
     } else {
-        code += variableName + QLatin1String(".deserialize(") + soapValueVarName + QLatin1String(".value());") + COMMENT;
+        code += variableName + QLatin1String(".deserialize(") + soapValueVarName + QLatin1String(");") + COMMENT;
     }
     if (optional) {
         code += variableName + QLatin1String("_nil = false;") + COMMENT;

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -483,13 +483,10 @@ void Converter::createComplexTypeSerializer(KODE::Class &newClass, const XSD::Co
             marshalCode += QLatin1String("mainValue.setType(") + typeArgs + QLatin1String(");");
             demarshalCode += typeName + "::deserialize(mainValue);";
         } else {
-            QString value;
             if (mTypeMap.isBuiltinType(baseName)) {
-                value = mTypeMap.serializeBuiltin(baseName, QName(), variableName, typeName);
-                marshalCode += QLatin1String("KDSoapValue mainValue(valueName, ") + value + QLatin1String(", ") + typeArgs + QLatin1String(");") + COMMENT;
+                marshalCode += QLatin1String("KDSoapValue mainValue = ") + mTypeMap.serializeBuiltin(baseName, QName(), variableName, "valueName", type->nameSpace(), type->name()) + QLatin1String(";") + COMMENT;
             } else {
-                value += variableName + QLatin1String(".serialize(valueName)");
-                marshalCode += QLatin1String("KDSoapValue mainValue = ") + value + QLatin1String(";") + COMMENT;
+                marshalCode += QLatin1String("KDSoapValue mainValue = ") + variableName + QLatin1String(".serialize(valueName);") + COMMENT;
                 marshalCode += QLatin1String("mainValue.setType(") + typeArgs + QLatin1String(");");
             }
             demarshalCode += demarshalVar(baseName, QName(), variableName, typeName, QLatin1String("mainValue"), false, false);

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -479,22 +479,19 @@ void Converter::createComplexTypeSerializer(KODE::Class &newClass, const XSD::Co
         const QString variableName = QLatin1String("d_ptr->") + variable.name();
 
         if (mTypeMap.isComplexType(baseName)) {
-            //marshalCode += QLatin1String("KDSoapValue mainValue = ") + variableName + QLatin1String(".serialize(valueName);") + COMMENT;
-            //marshalCode += QLatin1String("mainValue.setType(") + typeArgs + QLatin1String(");");
             marshalCode += QLatin1String("KDSoapValue mainValue = ") + typeName + QLatin1String("::serialize(valueName);") + COMMENT;
             marshalCode += QLatin1String("mainValue.setType(") + typeArgs + QLatin1String(");");
-            //demarshalCode += demarshalVar( baseName, QName(), variableName, typeName, QLatin1String("mainValue") );
-
             demarshalCode += typeName + "::deserialize(mainValue);";
-            //demarshalCode += demarshalVar( baseName, QName(), variableName, typeName, QLatin1String("mainValue") );
         } else {
             QString value;
             if (mTypeMap.isBuiltinType(baseName)) {
                 value = mTypeMap.serializeBuiltin(baseName, QName(), variableName, typeName);
+                marshalCode += QLatin1String("KDSoapValue mainValue(valueName, ") + value + QLatin1String(", ") + typeArgs + QLatin1String(");") + COMMENT;
             } else {
-                value += variableName + QLatin1String(".serialize()");
+                value += variableName + QLatin1String(".serialize(valueName)");
+                marshalCode += QLatin1String("KDSoapValue mainValue = ") + value + QLatin1String(";") + COMMENT;
+                marshalCode += QLatin1String("mainValue.setType(") + typeArgs + QLatin1String(");");
             }
-            marshalCode += QLatin1String("KDSoapValue mainValue(valueName, ") + value + QLatin1String(", ") + typeArgs + QLatin1String(");") + COMMENT;
             demarshalCode += demarshalVar(baseName, QName(), variableName, typeName, QLatin1String("mainValue"), false, false);
         }
 

--- a/kdwsdl2cpp/src/converter_simpletype.cpp
+++ b/kdwsdl2cpp/src/converter_simpletype.cpp
@@ -385,6 +385,7 @@ void Converter::createSimpleTypeSerializer(KODE::Class &newClass, const XSD::Sim
         {
             KODE::Code code;
             code += "QString str;";
+            code += "QXmlStreamNamespaceDeclarations decls;";
             code += "for ( int i = 0; i < " + variableName + ".count(); ++i ) {";
             code.indent();
             code += "if (!str.isEmpty())";
@@ -400,10 +401,13 @@ void Converter::createSimpleTypeSerializer(KODE::Class &newClass, const XSD::Sim
                     code += "KDSoapValue subValue =  " + variableName + ".at(i).serialize(QString());";
                 }
                 code += "str += subValue.value().toString();";
+                code += "decls += subValue.namespaceDeclarations();";
             }
             code.unindent();
             code += "}";
-            code += "return KDSoapValue(valueName, str, " + namespaceString(type->nameSpace()) + ", QString::fromLatin1(\"" + type->name() + "\"));";
+            code += "KDSoapValue value(valueName, str, " + namespaceString(type->nameSpace()) + ", QString::fromLatin1(\"" + type->name() + "\"));";
+            code += "value.setNamespaceDeclarations(decls);";
+            code += "return value;";
             serializeFunc.setBody(code);
         }
         {

--- a/kdwsdl2cpp/src/elementargumentserializer.cpp
+++ b/kdwsdl2cpp/src/elementargumentserializer.cpp
@@ -102,10 +102,8 @@ KODE::Code ElementArgumentSerializer::generate() const
             block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1Char('(') + mLocalVarName + op + QLatin1String("serialize(") + mNameArg + QLatin1String("));") + COMMENT;
         } else {
             if (mTypeMap.isBuiltinType(mType, mElementType)) {
-                const QString qtTypeName = mTypeMap.localType(mType, mElementType);
-                const QString value = mTypeMap.serializeBuiltin(mType, mElementType, mLocalVarName, qtTypeName);
-
-                block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String("(") + mNameArg + QLatin1String(", ") + value + QLatin1String(", ") + typeArgs + QLatin1String(");") + COMMENT;
+                const QString value = mTypeMap.serializeBuiltin(mType, mElementType, mLocalVarName, mNameArg, actualType.nameSpace(), actualType.localName());
+                block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String(" = ") + value + QLatin1String(";") + COMMENT;
             } else {
                 block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String(" = ") + mLocalVarName + QLatin1String(".serialize(") + mNameArg + QLatin1String(");") + COMMENT;
             }

--- a/kdwsdl2cpp/src/elementargumentserializer.cpp
+++ b/kdwsdl2cpp/src/elementargumentserializer.cpp
@@ -107,7 +107,7 @@ KODE::Code ElementArgumentSerializer::generate() const
 
                 block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String("(") + mNameArg + QLatin1String(", ") + value + QLatin1String(", ") + typeArgs + QLatin1String(");") + COMMENT;
             } else {
-                block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String("(") + mNameArg + QLatin1String(", ") + mLocalVarName + QLatin1String(".serialize(), ") + typeArgs + QLatin1String(");") + COMMENT;
+                block += QLatin1String("KDSoapValue ") + mValueVarName + QLatin1String(" = ") + mLocalVarName + QLatin1String(".serialize(") + mNameArg + QLatin1String(");") + COMMENT;
             }
         }
         if (!mNameNamespace.isEmpty()) {

--- a/kdwsdl2cpp/src/typemap.cpp
+++ b/kdwsdl2cpp/src/typemap.cpp
@@ -602,7 +602,7 @@ QString KWSDL::TypeMap::serializeBuiltin(const QName &baseTypeName, const QName 
     } else if (baseType.nameSpace() == XMLSchemaURI && baseType.localName() == "dateTime") {
         value = var + ".toDateString()";
     } else if (baseType.nameSpace() == XMLSchemaURI && baseType.localName() == "QName") {
-        value = "QVariant::fromValue(" +  var + ".qname()" + ")";
+        return var + ".toSoapValue(" + name + ", " + namespaceString(typeNameSpace) + ", QString::fromLatin1(\"" + typeName + "\"))";
     } else if (baseType.nameSpace() == XMLSchemaURI && baseType.localName() == "anySimpleType") {
         value = var;
     } else {

--- a/kdwsdl2cpp/src/typemap.cpp
+++ b/kdwsdl2cpp/src/typemap.cpp
@@ -92,7 +92,7 @@ TypeMap::TypeMap()
     addBuiltinType("nonPositiveInteger", "qint64"); // unbounded (-inf to 0)
     addBuiltinType("normalizedString", "QString");
     addBuiltinType("positiveInteger", "quint64"); // unbounded (1 to inf)
-    addBuiltinType("QName", "QString");
+    addBuiltinType("QName", "KDQName");
     addBuiltinType("short", "int"); // 16 bits. But QVariant doesn't support short.
     addBuiltinType("string", "QString");
     addBuiltinType("time", "QTime");
@@ -578,6 +578,9 @@ QString KWSDL::TypeMap::deserializeBuiltin(const QName &typeName, const QName &e
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "dateTime") {
         Q_ASSERT(qtTypeName == QLatin1String("KDDateTime"));
         return "KDDateTime::fromDateString(" + var + ".value().toString())";
+    } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "QName") {
+        Q_ASSERT(qtTypeName == QLatin1String("KDQName"));
+        return "KDQName::fromSoapValue(" + var + ")";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "anySimpleType") {
         return var + ".value()";
     } else {
@@ -597,6 +600,8 @@ QString KWSDL::TypeMap::serializeBuiltin(const QName &typeName, const QName &ele
         return "QString::fromLatin1(" + var + ".toBase64().constData())";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "dateTime") {
         return var + ".toDateString()";
+    } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "QName") {
+        return"QVariant::fromValue(" +  var + ".qname()" + ")";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "anySimpleType") {
         return var;
     } else {

--- a/kdwsdl2cpp/src/typemap.cpp
+++ b/kdwsdl2cpp/src/typemap.cpp
@@ -572,16 +572,16 @@ QString KWSDL::TypeMap::deserializeBuiltin(const QName &typeName, const QName &e
 {
     const QName type = typeName.isEmpty() ? baseTypeForElement(elementName) : typeName;
     if (type.nameSpace() == XMLSchemaURI && type.localName() == "hexBinary") {
-        return "QByteArray::fromHex(" + var + ".toString().toLatin1())";
+        return "QByteArray::fromHex(" + var + ".value().toString().toLatin1())";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "base64Binary") {
-        return "QByteArray::fromBase64(" + var + ".toString().toLatin1())";
+        return "QByteArray::fromBase64(" + var + ".value().toString().toLatin1())";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "dateTime") {
         Q_ASSERT(qtTypeName == QLatin1String("KDDateTime"));
-        return "KDDateTime::fromDateString(" + var + ".toString())";
+        return "KDDateTime::fromDateString(" + var + ".value().toString())";
     } else if (type.nameSpace() == XMLSchemaURI && type.localName() == "anySimpleType") {
-        return var;
+        return var + ".value()";
     } else {
-        return var + ".value<" + qtTypeName + ">()";
+        return var + ".value().value<" + qtTypeName + ">()";
     }
 }
 

--- a/kdwsdl2cpp/src/typemap.h
+++ b/kdwsdl2cpp/src/typemap.h
@@ -108,7 +108,7 @@ public:
      * Return C++ code for converting the variant in "var" into the right type.
      */
     QString deserializeBuiltin(const QName &typeName, const QName &elementName, const QString &var, const QString &qtTypeName) const;
-    QString serializeBuiltin(const QName &typeName, const QName &elementName, const QString &var, const QString &qtTypeName) const;
+    QString serializeBuiltin(const QName &baseTypeName, const QName &elementName, const QString &var, const QString &name, const QString &typeNameSpace, const QString &typeName) const;
 
     QString localTypeForAttribute(const QName &typeName) const;
     QStringList headersForAttribute(const QName &typeName) const;

--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
   KDSoapFaultException.cpp
   KDSoapMessageAddressingProperties.cpp
   KDSoapEndpointReference.cpp
+  KDQName.cpp
 )
 
 add_library(kdsoap ${KDSoap_LIBRARY_MODE} ${SOURCES})
@@ -67,6 +68,7 @@ if(KDSoap_IS_ROOT_PROJECT)
       KDSoapEndpointReference
       KDSoapPendingCall
       KDSoapAuthentication
+      KDQName
     COMMON_HEADER
       KDSoapClient
   )
@@ -88,6 +90,7 @@ if(KDSoap_IS_ROOT_PROJECT)
     KDSoapFaultException.h
     KDSoapMessageAddressingProperties.h
     KDSoapEndpointReference.h
+    KDQName.h
     DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient
   )
 

--- a/src/KDSoapClient/KDQName.cpp
+++ b/src/KDSoapClient/KDQName.cpp
@@ -1,0 +1,126 @@
+/*
+    This file is part of KDE Schema Parser
+
+    Copyright (c) 2005 Tobias Koenig <tokoe@kde.org>
+                       based on wsdlpull parser by Vivek Krishna
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+ */
+
+#include "KDQName.h"
+#include <QDebug>
+
+#include <KDSoapValue>
+
+KDQName::KDQName()
+{
+}
+
+KDQName::KDQName( const QString &name )
+{
+    parse( name );
+}
+
+KDQName::KDQName( const QString &nameSpace, const QString &localName )
+    : mNameSpace( nameSpace ), mLocalName( localName )
+{
+    Q_ASSERT(!localName.contains(QLatin1Char(':')));
+}
+
+void KDQName::operator=( const QString &name )
+{
+    parse( name );
+}
+
+QString KDQName::localName() const
+{
+    return mLocalName;
+}
+
+QString KDQName::prefix() const
+{
+    return mPrefix;
+}
+
+QString KDQName::qname() const
+{
+    if ( mPrefix.isEmpty() )
+        return mLocalName;
+    else
+        return mPrefix + QLatin1Char(':') + mLocalName;
+}
+
+void KDQName::setNameSpace( const QString &nameSpace )
+{
+    mNameSpace = nameSpace;
+}
+
+QString KDQName::nameSpace() const
+{
+    return mNameSpace;
+}
+
+bool KDQName::operator==( const KDQName &qname ) const
+{
+    return (qname.nameSpace() == mNameSpace && qname.localName() == mLocalName);
+}
+
+bool KDQName::operator!=( const KDQName &qname ) const
+{
+    return !operator==( qname );
+}
+
+bool KDQName::isEmpty() const
+{
+    return (mNameSpace.isEmpty() && mLocalName.isEmpty());
+}
+
+KDQName KDQName::fromSoapValue(const KDSoapValue &value)
+{
+    KDQName qname;
+    qname.parse(value.value().toString());
+
+    QXmlStreamNamespaceDeclarations decls = value.namespaceDeclarations();
+    for (int i = 0; i < decls.count(); ++i) {
+        const QXmlStreamNamespaceDeclaration &decl = decls.at(i);
+        if (decl.prefix() == qname.prefix()) {
+            qname.setNameSpace(decl.namespaceUri().toString());
+        }
+    }
+
+    return qname;
+}
+
+void KDQName::parse( const QString &str )
+{
+    int pos = str.indexOf( QLatin1Char(':') );
+    if ( pos != -1 ) {
+        mPrefix = str.left( pos );
+        mLocalName = str.mid( pos + 1 );
+    } else {
+        mLocalName = str;
+    }
+    Q_ASSERT(!mLocalName.contains(QLatin1Char(':')));
+}
+
+QDebug operator <<(QDebug dbg, const KDQName &qn)
+{
+    if (!qn.nameSpace().isEmpty())
+        dbg << "(" << qn.nameSpace() << "," << qn.localName() << ")";
+    else
+        dbg << qn.qname();
+    return dbg;
+}

--- a/src/KDSoapClient/KDQName.cpp
+++ b/src/KDSoapClient/KDQName.cpp
@@ -93,7 +93,7 @@ KDQName KDQName::fromSoapValue(const KDSoapValue &value)
     KDQName qname;
     qname.parse(value.value().toString());
 
-    QXmlStreamNamespaceDeclarations decls = value.namespaceDeclarations();
+    QXmlStreamNamespaceDeclarations decls = value.environmentNamespaceDeclarations();
     for (int i = 0; i < decls.count(); ++i) {
         const QXmlStreamNamespaceDeclaration &decl = decls.at(i);
         if (decl.prefix() == qname.prefix()) {

--- a/src/KDSoapClient/KDQName.cpp
+++ b/src/KDSoapClient/KDQName.cpp
@@ -104,6 +104,16 @@ KDQName KDQName::fromSoapValue(const KDSoapValue &value)
     return qname;
 }
 
+KDSoapValue KDQName::toSoapValue(const QString &name, const QString &typeNameSpace, const QString &typeName) const
+{
+    KDSoapValue value = KDSoapValue(name, qname(), typeNameSpace, typeName);
+    if ( !mPrefix.isEmpty() && !mNameSpace.isEmpty() ) {
+        QXmlStreamNamespaceDeclaration decl(mPrefix, mNameSpace);
+        value.addNamespaceDeclaration(decl);
+    }
+    return value;
+}
+
 void KDQName::parse( const QString &str )
 {
     int pos = str.indexOf( QLatin1Char(':') );

--- a/src/KDSoapClient/KDQName.h
+++ b/src/KDSoapClient/KDQName.h
@@ -63,6 +63,11 @@ class KDSOAP_EXPORT KDQName
      */
     static KDQName fromSoapValue(const KDSoapValue &value);
 
+    /**
+     * Returns a KDSoapValue representation.
+     */
+    KDSoapValue toSoapValue(const QString &name, const QString &typeNameSpace = QString(), const QString &typeName = QString()) const;
+
   private:
     void parse( const QString& );
 

--- a/src/KDSoapClient/KDQName.h
+++ b/src/KDSoapClient/KDQName.h
@@ -26,6 +26,7 @@
 #include <QString>
 #include <QList>
 #include <QHash>
+#include <QMetaType>
 
 class KDSoapValue;
 

--- a/src/KDSoapClient/KDQName.h
+++ b/src/KDSoapClient/KDQName.h
@@ -1,0 +1,80 @@
+/*
+    This file is part of KDE.
+
+    Copyright (c) 2005 Tobias Koenig <tokoe@kde.org>
+                       based on wsdlpull parser by Vivek Krishna
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+ */
+
+#ifndef KDQNAME_H
+#define KDQNAME_H
+
+#include <QString>
+#include <QList>
+#include <QHash>
+
+class KDSoapValue;
+
+#include "KDSoapGlobal.h"
+
+class KDSOAP_EXPORT KDQName
+{
+  public:
+    typedef QList<KDQName> List;
+
+    KDQName();
+
+    // Create a KDQName with prefix+localname
+    explicit KDQName( const QString &name );
+
+    // Create a KDQName with namespace+localname
+    KDQName( const QString &nameSpace, const QString &localName );
+
+    void operator=( const QString &name );
+
+    QString localName() const;
+    QString prefix() const;
+    QString qname() const;
+
+    void setNameSpace( const QString &nameSpace );
+    QString nameSpace() const;
+
+    bool operator==( const KDQName& ) const;
+    bool operator!=( const KDQName& ) const;
+
+    bool isEmpty() const;
+
+    /**
+     * Creates a KDQName from a KDSoapValue.
+     */
+    static KDQName fromSoapValue(const KDSoapValue &value);
+
+  private:
+    void parse( const QString& );
+
+    QString mNameSpace;
+    QString mLocalName;
+    QString mPrefix;
+};
+
+Q_DECLARE_METATYPE(KDQName)
+
+inline uint qHash(const KDQName& qn) { return qHash(qn.nameSpace())^qHash(qn.localName()); }
+
+QDebug operator<<(QDebug dbg, const KDQName &qn);
+
+#endif

--- a/src/KDSoapClient/KDSoapMessageReader.cpp
+++ b/src/KDSoapClient/KDSoapMessageReader.cpp
@@ -92,10 +92,12 @@ static int xmlTypeToMetaType(const QString &xmlType)
 
 static KDSoapValue parseElement(QXmlStreamReader &reader, const QXmlStreamNamespaceDeclarations &envNsDecls)
 {
+    const QXmlStreamNamespaceDeclarations combinedNamespaceDeclarations = envNsDecls + reader.namespaceDeclarations();
     const QString name = reader.name().toString();
     KDSoapValue val(name, QVariant());
     val.setNamespaceUri(reader.namespaceUri().toString());
     val.setNamespaceDeclarations(reader.namespaceDeclarations());
+    val.setEnvironmentNamespaceDeclarations(combinedNamespaceDeclarations);
     //qDebug() << "parsing" << name;
     QVariant::Type metaTypeId = QVariant::Invalid;
 
@@ -113,7 +115,7 @@ static KDSoapValue parseElement(QXmlStreamReader &reader, const QXmlStreamNamesp
                 const QString type = attrValue.toString();
                 const int pos = type.indexOf(QLatin1Char(':'));
                 const QString dataType = type.mid(pos + 1);
-                val.setType(namespaceForPrefix(envNsDecls, type.left(pos)).toString(), dataType);
+                val.setType(namespaceForPrefix(combinedNamespaceDeclarations, type.left(pos)).toString(), dataType);
                 metaTypeId = static_cast<QVariant::Type>(xmlTypeToMetaType(dataType));
             }
             continue;
@@ -133,7 +135,7 @@ static KDSoapValue parseElement(QXmlStreamReader &reader, const QXmlStreamNamesp
             text = reader.text().toString();
             //qDebug() << "text=" << text;
         } else if (reader.isStartElement()) {
-            const KDSoapValue subVal = parseElement(reader, envNsDecls); // recurse
+            const KDSoapValue subVal = parseElement(reader, combinedNamespaceDeclarations); // recurse
             val.childValues().append(subVal);
         }
     }

--- a/src/KDSoapClient/KDSoapMessageReader.cpp
+++ b/src/KDSoapClient/KDSoapMessageReader.cpp
@@ -95,6 +95,7 @@ static KDSoapValue parseElement(QXmlStreamReader &reader, const QXmlStreamNamesp
     const QString name = reader.name().toString();
     KDSoapValue val(name, QVariant());
     val.setNamespaceUri(reader.namespaceUri().toString());
+    val.setNamespaceDeclarations(reader.namespaceDeclarations());
     //qDebug() << "parsing" << name;
     QVariant::Type metaTypeId = QVariant::Invalid;
 

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -367,6 +367,20 @@ QString KDSoapValue::type() const
     return d->m_typeName;
 }
 
+KDSoapValueList KDSoapValue::split() const
+{
+    KDSoapValueList valueList;
+    if (value().toString().trimmed().isEmpty()) return valueList;
+
+    const QStringList list = value().toString().split(QLatin1Char(' '));
+    for (int i = 0; i < list.count(); ++i) {
+        KDSoapValue value(*this);
+        value.setValue(list.at(i));
+        valueList << value;
+    }
+    return valueList;
+}
+
 KDSoapValue KDSoapValueList::child(const QString &name) const
 {
     const_iterator it = begin();

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -43,6 +43,7 @@ public:
     KDSoapValueList m_childValues;
     bool m_qualified;
     bool m_nillable;
+    QXmlStreamNamespaceDeclarations m_namespaceDeclarations;
 };
 
 uint qHash(const KDSoapValue &value)
@@ -118,6 +119,16 @@ bool KDSoapValue::isQualified() const
 void KDSoapValue::setQualified(bool qualified)
 {
     d->m_qualified = qualified;
+}
+
+void KDSoapValue::setNamespaceDeclarations(const QXmlStreamNamespaceDeclarations &namespaceDeclarations)
+{
+    d->m_namespaceDeclarations = namespaceDeclarations;
+}
+
+QXmlStreamNamespaceDeclarations KDSoapValue::namespaceDeclarations() const
+{
+    return d->m_namespaceDeclarations;
 }
 
 KDSoapValueList &KDSoapValue::childValues() const

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -126,6 +126,11 @@ void KDSoapValue::setNamespaceDeclarations(const QXmlStreamNamespaceDeclarations
     d->m_namespaceDeclarations = namespaceDeclarations;
 }
 
+void KDSoapValue::addNamespaceDeclaration(const QXmlStreamNamespaceDeclaration &namespaceDeclaration)
+{
+    d->m_namespaceDeclarations.append(namespaceDeclaration);
+}
+
 QXmlStreamNamespaceDeclarations KDSoapValue::namespaceDeclarations() const
 {
     return d->m_namespaceDeclarations;
@@ -284,6 +289,10 @@ void KDSoapValue::writeElement(KDSoapNamespacePrefixes &namespacePrefixes, QXmlS
 void KDSoapValue::writeElementContents(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, KDSoapValue::Use use, const QString &messageNamespace) const
 {
     const QVariant value = this->value();
+
+    foreach (QXmlStreamNamespaceDeclaration decl, d->m_namespaceDeclarations) {
+        writer.writeNamespace(decl.namespaceUri().toString(), decl.prefix().toString());
+    }
 
     if (isNil() && d->m_nillable) {
         writer.writeAttribute(KDSoapNamespaceManager::xmlSchemaInstance2001(), QLatin1String("nil"), QLatin1String("true"));

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -44,7 +44,8 @@ public:
     KDSoapValueList m_childValues;
     bool m_qualified;
     bool m_nillable;
-    QXmlStreamNamespaceDeclarations m_namespaceDeclarations;
+    QXmlStreamNamespaceDeclarations m_environmentNamespaceDeclarations;
+    QXmlStreamNamespaceDeclarations m_localNamespaceDeclarations;
 };
 
 uint qHash(const KDSoapValue &value)
@@ -124,17 +125,27 @@ void KDSoapValue::setQualified(bool qualified)
 
 void KDSoapValue::setNamespaceDeclarations(const QXmlStreamNamespaceDeclarations &namespaceDeclarations)
 {
-    d->m_namespaceDeclarations = namespaceDeclarations;
+    d->m_localNamespaceDeclarations = namespaceDeclarations;
 }
 
 void KDSoapValue::addNamespaceDeclaration(const QXmlStreamNamespaceDeclaration &namespaceDeclaration)
 {
-    d->m_namespaceDeclarations.append(namespaceDeclaration);
+    d->m_localNamespaceDeclarations.append(namespaceDeclaration);
 }
 
 QXmlStreamNamespaceDeclarations KDSoapValue::namespaceDeclarations() const
 {
-    return d->m_namespaceDeclarations;
+    return d->m_localNamespaceDeclarations;
+}
+
+void KDSoapValue::setEnvironmentNamespaceDeclarations(const QXmlStreamNamespaceDeclarations &environmentNamespaceDeclarations)
+{
+    d->m_environmentNamespaceDeclarations = environmentNamespaceDeclarations;
+}
+
+QXmlStreamNamespaceDeclarations KDSoapValue::environmentNamespaceDeclarations() const
+{
+    return d->m_environmentNamespaceDeclarations;
 }
 
 KDSoapValueList &KDSoapValue::childValues() const
@@ -291,7 +302,7 @@ void KDSoapValue::writeElementContents(KDSoapNamespacePrefixes &namespacePrefixe
 {
     const QVariant value = this->value();
 
-    foreach (const QXmlStreamNamespaceDeclaration& decl, d->m_namespaceDeclarations) {
+    foreach (const QXmlStreamNamespaceDeclaration& decl, d->m_localNamespaceDeclarations) {
         writer.writeNamespace(decl.namespaceUri().toString(), decl.prefix().toString());
     }
 

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -27,6 +27,7 @@
 #include <QDateTime>
 #include <QUrl>
 #include <QDebug>
+#include <QStringList>
 
 class KDSoapValue::Private : public QSharedData
 {

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -291,7 +291,7 @@ void KDSoapValue::writeElementContents(KDSoapNamespacePrefixes &namespacePrefixe
 {
     const QVariant value = this->value();
 
-    foreach (QXmlStreamNamespaceDeclaration decl, d->m_namespaceDeclarations) {
+    foreach (const QXmlStreamNamespaceDeclaration& decl, d->m_namespaceDeclarations) {
         writer.writeNamespace(decl.namespaceUri().toString(), decl.prefix().toString());
     }
 
@@ -391,9 +391,8 @@ QString KDSoapValue::type() const
 KDSoapValueList KDSoapValue::split() const
 {
     KDSoapValueList valueList;
-    if (value().toString().trimmed().isEmpty()) return valueList;
-
-    const QStringList list = value().toString().split(QLatin1Char(' '));
+    const QStringList list = value().toString().split(QLatin1Char(' '), QString::SkipEmptyParts);
+    valueList.reserve(list.count());
     for (int i = 0; i < list.count(); ++i) {
         KDSoapValue value(*this);
         value.setValue(list.at(i));

--- a/src/KDSoapClient/KDSoapValue.h
+++ b/src/KDSoapClient/KDSoapValue.h
@@ -241,6 +241,13 @@ public:
     QString type() const;
 
     /**
+     * Returns the list of split values.
+     * The data is split on spaces and the properties are copied.
+     * \since 1.8
+     */
+    KDSoapValueList split() const;
+
+    /**
      * Defines the way the message should be serialized.
      * See the "use" attribute for soap:body, in the WSDL file.
      */

--- a/src/KDSoapClient/KDSoapValue.h
+++ b/src/KDSoapClient/KDSoapValue.h
@@ -248,6 +248,12 @@ public:
     void setNamespaceDeclarations(const QXmlStreamNamespaceDeclarations& namespaceDeclarations);
 
     /**
+     * Adds a \p namespaceDeclaration to the existing list of namespaceDeclarations.
+     * \since 1.8
+     */
+    void addNamespaceDeclaration(const QXmlStreamNamespaceDeclaration& namespaceDeclaration);
+
+    /**
      * Returns the namespaceDeclarations as it was during parsing of the message
      * \since 1.8
      */

--- a/src/KDSoapClient/KDSoapValue.h
+++ b/src/KDSoapClient/KDSoapValue.h
@@ -30,6 +30,7 @@
 #include <QtCore/QSet>
 #include <QtCore/QVector>
 #include <QtCore/QSharedDataPointer>
+#include <QtCore/QXmlStreamNamespaceDeclarations>
 #include "KDSoapGlobal.h"
 
 #ifndef QT_NO_STL
@@ -239,6 +240,18 @@ public:
      * Example: "string".
      */
     QString type() const;
+
+    /**
+     * Sets the \p namespaceDeclarations of this value.
+     * \since 1.8
+     */
+    void setNamespaceDeclarations(const QXmlStreamNamespaceDeclarations& namespaceDeclarations);
+
+    /**
+     * Returns the namespaceDeclarations as it was during parsing of the message
+     * \since 1.8
+     */
+    QXmlStreamNamespaceDeclarations namespaceDeclarations() const;
 
     /**
      * Returns the list of split values.

--- a/src/KDSoapClient/KDSoapValue.h
+++ b/src/KDSoapClient/KDSoapValue.h
@@ -254,10 +254,22 @@ public:
     void addNamespaceDeclaration(const QXmlStreamNamespaceDeclaration& namespaceDeclaration);
 
     /**
-     * Returns the namespaceDeclarations as it was during parsing of the message
+     * Returns the namespaceDeclarations of this value as it was during parsing of the message
      * \since 1.8
      */
     QXmlStreamNamespaceDeclarations namespaceDeclarations() const;
+
+    /**
+     * Sets the \p environmentNamespaceDeclarations of this value.
+     * \since 1.8
+     */
+    void setEnvironmentNamespaceDeclarations(const QXmlStreamNamespaceDeclarations& environmentNamespaceDeclarations);
+
+    /**
+     * Returns the namespaceDeclarations of this value and its parents combined as it was during parsing of the message
+     * \since 1.8
+     */
+    QXmlStreamNamespaceDeclarations environmentNamespaceDeclarations() const;
 
     /**
      * Returns the list of split values.

--- a/unittests/empty_list_wsdl/empty_list_wsdl.cpp
+++ b/unittests/empty_list_wsdl/empty_list_wsdl.cpp
@@ -35,7 +35,9 @@ private Q_SLOTS:
   void testMustReturnEmptyListWhenXmlValueIsEmpty()
   {
     NS2__Orientation list;
-    list.deserialize(QVariant::fromValue(QString("")));
+    KDSoapValue soapValue;
+    soapValue.setValue(QVariant::fromValue(QString("")));
+    list.deserialize(soapValue);
     QVERIFY(list.entries().empty());
   }
 
@@ -43,14 +45,18 @@ private Q_SLOTS:
   {
     NS2__Orientation list;
     QVariant null;
-    list.deserialize(null);
+    KDSoapValue soapValue;
+    soapValue.setValue(null);
+    list.deserialize(soapValue);
     QVERIFY(list.entries().empty());
   }
 
   void testMustReturnEmptyListWhenXmlContainsOnlySpaces()
   {
     NS2__Orientation list;
-    list.deserialize(QVariant::fromValue(QString("    \t   \t")));
+    KDSoapValue soapValue;
+    soapValue.setValue(QVariant::fromValue(QString("    \t   \t")));
+    list.deserialize(soapValue);
     QVERIFY(list.entries().empty());
   }
 };

--- a/unittests/enum_escape/test_enum.cpp
+++ b/unittests/enum_escape/test_enum.cpp
@@ -52,7 +52,9 @@ void TestEnum::test()
     ar.setType(TNS__AudienceRating::_6Bis);
 
     QVariant var = ar.serialize();
-    ar.deserialize(var);
+    KDSoapValue soapValue;
+    soapValue.setValue(var);
+    ar.deserialize(soapValue);
 
     QCOMPARE(ar.type(), TNS__AudienceRating::_6Bis);
 }

--- a/unittests/enum_escape/test_enum.cpp
+++ b/unittests/enum_escape/test_enum.cpp
@@ -51,9 +51,7 @@ void TestEnum::test()
     ar.setType(TNS__AudienceRating::Http___f_q_d_n_ext_enum2);
     ar.setType(TNS__AudienceRating::_6Bis);
 
-    QVariant var = ar.serialize();
-    KDSoapValue soapValue;
-    soapValue.setValue(var);
+    KDSoapValue soapValue = ar.serialize(QString());
     ar.deserialize(soapValue);
 
     QCOMPARE(ar.type(), TNS__AudienceRating::_6Bis);

--- a/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
+++ b/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
 ** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Casper Meijn  <casper@meijn.net>
 ** All rights reserved.
 **
 ** This file is part of the KD Soap library.
@@ -39,10 +40,10 @@ private Q_SLOTS:
     void testGeneratingProbe()
     {
         // Types
-        QStringList typeList;
-        typeList << "i:PrintBasic"; //namespace: http://printer.example.org/2003/imaging
+        KDQName type(QString("i:PrintBasic"));
+        type.setNameSpace(QString("http://printer.example.org/2003/imaging"));
         TNS__QNameListType types;
-        types.setEntries(typeList);
+        types.setEntries(QList<KDQName>() << type);
 
         // Scopes
         QStringList uriStringList;
@@ -67,7 +68,7 @@ private Q_SLOTS:
                            " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
                            " xmlns:soap-enc=\"http://schemas.xmlsoap.org/soap/encoding/\""
                            " xmlns:n1=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\">"
-                           "<n1:Types>i:PrintBasic</n1:Types>"
+                           "<n1:Types xmlns:i=\"http://printer.example.org/2003/imaging\">i:PrintBasic</n1:Types>"
                            "<n1:Scopes MatchBy=\"http://schemas.xmlsoap.org/ws/2005/04/discovery/ldap\">"
                            "ldap:///ou=engineering,o=examplecom,c=us"
                            "</n1:Scopes>"
@@ -121,10 +122,14 @@ private Q_SLOTS:
         QCOMPARE(probeMatchList.size(), 1);
         const TNS__ProbeMatchType& probeMatch = probeMatchList.value(0);
         QCOMPARE(QString(probeMatch.endpointReference().address()), QString("uuid:98190dc2-0890-4ef8-ac9a-5940995e6119"));
-        const QStringList& typeList = probeMatch.types().entries();
+        const QList<KDQName>& typeList = probeMatch.types().entries();
         QCOMPARE(typeList.size(), 2);
-        QCOMPARE(typeList.value(0), QString("i:PrintBasic"));
-        QCOMPARE(typeList.value(1), QString("i:PrintAdvanced"));
+        QCOMPARE(typeList.value(0).localName(), QString("PrintBasic"));
+        QCOMPARE(typeList.value(0).prefix(), QString("i"));
+        QCOMPARE(typeList.value(0).nameSpace(), QString("http://printer.example.org/2003/imaging"));
+        QCOMPARE(typeList.value(1).localName(), QString("PrintAdvanced"));
+        QCOMPARE(typeList.value(1).prefix(), QString("i"));
+        QCOMPARE(typeList.value(1).nameSpace(), QString("http://printer.example.org/2003/imaging"));
         const QStringList& scopeList = probeMatch.scopes().value().entries();
         QCOMPARE(scopeList.size(), 3);
         QCOMPARE(scopeList.value(0), QString("ldap:///ou=engineering,o=examplecom,c=us"));

--- a/unittests/wsdl_document/test_wsdl_document.cpp
+++ b/unittests/wsdl_document/test_wsdl_document.cpp
@@ -1060,7 +1060,7 @@ void WsdlDocumentTest::testSendTelegram()
 
     // Check the request as received by the server.
     const QByteArray expectedRequestXml =
-        QByteArray(xmlBegin) + "<TelegramRequest " + xmlNamespaces + ">"
+        QByteArray(xmlBegin) + "<TelegramRequest " + xmlNamespaces + " xmlns:n1=\"http://www.kdab.com/xml/MyWsdl/\">"
         "<TelegramHex>48656c6c6f</TelegramHex>"
         "<TelegramBase64>SGVsbG8=</TelegramBase64>"
         "</TelegramRequest>";


### PR DESCRIPTION
These change add support for sending and receiving qnames. It adds a new KDQName class, this is used to represent the xml qname and the reader and writer are extended to support it.

I am not sure whether this will break existing code, as the soap qname are now represented as KDQName instead of QString. But qnames couldn't be fully used in the past, as the xml namespaces were not correctly passed to the reader/writer.

I am not sure whether this is the simplest solution. I am open for suggestion for simplifying it.