### PR TITLE
WS-Addressing reader

### DIFF
--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -269,7 +269,7 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
     Q_UNUSED(messageNamespace);
     Q_UNUSED(forceQualified);
 
-    if (d->destination == predefinedAddressToString(None) || d->destination.isEmpty()) {
+    if (d->destination == predefinedAddressToString(None)) {
         return;
     }
 
@@ -279,13 +279,17 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
 
     const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
 
-    writer.writeStartElement(addressingNS, QLatin1String("To"));
-    writer.writeCharacters(d->destination);
-    writer.writeEndElement();
+    if (!d->destination.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("To"));
+        writer.writeCharacters(d->destination);
+        writer.writeEndElement();
+    }
 
-    writer.writeStartElement(addressingNS, QLatin1String("From"));
-    writeAddressField(writer, d->sourceEndpoint.address());
-    writer.writeEndElement();
+    if (!d->sourceEndpoint.isEmpty()) {
+        writer.writeStartElement(addressingNS, QLatin1String("From"));
+        writeAddressField(writer, d->sourceEndpoint.address());
+        writer.writeEndElement();
+    }
 
     if (!d->replyEndpoint.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("ReplyTo"));

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.h
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.h
@@ -83,6 +83,7 @@ class KDSOAP_EXPORT KDSoapMessageAddressingProperties
 {
 public:
     friend class KDSoapMessageWriter;
+    friend class KDSoapMessageReader;
 
     /**
      * This enum contains all the predefined addresses defined by the ws addressing specification
@@ -270,11 +271,21 @@ public:
      */
     static QString predefinedAddressToString(KDSoapAddressingPredefinedAddress address);
 
+    /**
+     * Helper function that compares \p namespaceUri with the known WS-Addressing namespaces
+     */
+    static bool isWSAddressingNamespace(const QString& namespaceUri);
+
 private:
     /**
      * Private method called to write the properties to the soap header, using QXmlStreamWriter
      */
     void writeMessageAddressingProperties(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &messageNamespace, bool forceQualified) const;
+
+    /**
+     * Private method called to read a property from a soap header
+     */
+    void readMessageAddressingProperty(const KDSoapValue& value);
 
 private:
     QSharedDataPointer<KDSoapMessageAddressingPropertiesData> d;

--- a/src/KDSoapClient/KDSoapMessageReader.cpp
+++ b/src/KDSoapClient/KDSoapMessageReader.cpp
@@ -214,11 +214,18 @@ KDSoapMessageReader::XmlError KDSoapMessageReader::xmlToMessage(const QByteArray
             if (readNextStartElement(reader)) {
                 if (reader.name() == QLatin1String("Header") && (reader.namespaceUri() == KDSoapNamespaceManager::soapEnvelope() ||
                         reader.namespaceUri() == KDSoapNamespaceManager::soapEnvelope200305())) {
+                    KDSoapMessageAddressingProperties messageAddressingProperties;
                     while (readNextStartElement(reader)) {
-                        KDSoapMessage header;
-                        static_cast<KDSoapValue &>(header) = parseElement(reader, envNsDecls);
-                        pRequestHeaders->append(header);
+                        if (KDSoapMessageAddressingProperties::isWSAddressingNamespace(reader.namespaceUri().toString())) {
+                            KDSoapValue value = parseElement(reader, envNsDecls);
+                            messageAddressingProperties.readMessageAddressingProperty(value);
+                        } else {
+                            KDSoapMessage header;
+                            static_cast<KDSoapValue &>(header) = parseElement(reader, envNsDecls);
+                            pRequestHeaders->append(header);
+                        }
                     }
+                    pMsg->setMessageAddressingProperties(messageAddressingProperties);
                     readNextStartElement(reader); // read <Body>
                 }
                 if (reader.name() == QLatin1String("Body") && (reader.namespaceUri() == KDSoapNamespaceManager::soapEnvelope() ||

--- a/src/KDSoapClient/KDSoapNamespaceManager.cpp
+++ b/src/KDSoapClient/KDSoapNamespaceManager.cpp
@@ -70,3 +70,18 @@ QString KDSoapNamespaceManager::soapMessageAddressing()
 {
     return QString::fromLatin1("http://www.w3.org/2005/08/addressing");
 }
+
+QString KDSoapNamespaceManager::soapMessageAddressing200303()
+{
+    return QString::fromLatin1("http://schemas.xmlsoap.org/ws/2003/03/addressing");
+}
+
+QString KDSoapNamespaceManager::soapMessageAddressing200403()
+{
+    return QString::fromLatin1("http://schemas.xmlsoap.org/ws/2004/03/addressing");
+}
+
+QString KDSoapNamespaceManager::soapMessageAddressing200408()
+{
+    return QString::fromLatin1("http://schemas.xmlsoap.org/ws/2004/08/addressing");
+}

--- a/src/KDSoapClient/KDSoapNamespaceManager.h
+++ b/src/KDSoapClient/KDSoapNamespaceManager.h
@@ -41,6 +41,9 @@ public:
     static QString soapEncoding();
     static QString soapEncoding200305();
     static QString soapMessageAddressing();
+    static QString soapMessageAddressing200303();
+    static QString soapMessageAddressing200403();
+    static QString soapMessageAddressing200408();
 
 private: // TODO instantiate to handle custom namespaces per clientinterface
     KDSoapNamespaceManager();


### PR DESCRIPTION
This pull request adds support for reading WS-Addressing headers for incoming messages. The WS-Addressing headers are placed in KDSoapMessageAddressingProperties, so that the application can use them easily.

It also has a patch for the WS-Addressing writer which doesn't requires destination and source as the [spec](https://www.w3.org/TR/2006/REC-ws-addr-core-20060509/) says they are optional.