### PR TITLE
Fix if a referenced type name has an extra space on the ends. 

### DIFF
--- a/kdwsdl2cpp/schema/parser.cpp
+++ b/kdwsdl2cpp/schema/parser.cpp
@@ -487,7 +487,7 @@ Element Parser::parseElement(ParserContext *context,
     newElement.setNillable(stringToBoolean(element.attribute(QLatin1String("nillable"))));
 
     if (element.hasAttribute(QLatin1String("type"))) {
-        QName typeName(element.attribute(QLatin1String("type")));
+        QName typeName(element.attribute(QLatin1String("type")).trimmed());
         typeName.setNameSpace(context->namespaceManager()->uri(typeName.prefix()));
         if (debugParsing()) {
             qDebug() << "typeName=" << typeName.qname() << "namespace=" << context->namespaceManager()->uri(typeName.prefix());


### PR DESCRIPTION
E.g. allow the type name "xs:string " to work. For when you can't fix the source WSDL.