### PR TITLE
Generate "hasValueFor{Value}" functions

### DIFF
--- a/kdwsdl2cpp/src/compiler.cpp
+++ b/kdwsdl2cpp/src/compiler.cpp
@@ -108,6 +108,7 @@ void Compiler::parse(const QDomElement &element)
         wsdl.setDefinitions(definitions);
         wsdl.setNamespaceManager(namespaceManager);
 
+        KODE::Code::setDefaultIndentation(4);
         KWSDL::Converter converter;
         converter.setWSDL(wsdl);
 

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -285,7 +285,7 @@ QString Converter::generateMemberVariable(const QString &rawName, const QString 
     }
 
     // setter method
-    const QString argName = '_' + memberName;
+    const QString argName = "arg_" + memberName;
     KODE::Function setter(QLatin1String("set") + upperName, QLatin1String("void"), access);
     setter.addArgument(inputTypeName + QLatin1Char(' ') + argName);
     KODE::Code code;
@@ -391,7 +391,11 @@ QString Converter::generateMemberVariable(const QString &rawName, const QString 
 
     if (optional) {
         KODE::Code checkerCode;
-        checkerCode += QLatin1String("return ") + variableName + QLatin1String("_nil == false;");
+        if (usePointer) {
+            checkerCode += QLatin1String("return ") + variableName + QLatin1String(".isNull() == false;");
+        } else {
+            checkerCode += QLatin1String("return ") + variableName + QLatin1String("_nil == false;");
+        }
 
         KODE::Function checker(QLatin1String("hasValueFor") + upperName, QLatin1String("bool"), access);
         checker.setConst(true);

--- a/kdwsdl2cpp/src/creator.cpp
+++ b/kdwsdl2cpp/src/creator.cpp
@@ -31,8 +31,6 @@ using namespace KWSDL;
 
 Creator::Creator()
 {
-    KODE::Code::setDefaultIndentation(4);
-
     // Set generated header details.
     _printer.setCreationWarning(true);
     _printer.setGenerator(QLatin1String("KDAB's kdwsdl2cpp"));

--- a/unittests/optionaltype_regular/test.wsdl
+++ b/unittests/optionaltype_regular/test.wsdl
@@ -8,6 +8,22 @@
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
+
+      <xs:complexType name="PolymorphicClass">
+        <xs:sequence>
+          <xs:element name="value" type="xsd:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="DerivedClass">
+        <xs:complexContent>
+          <xs:extension base="tns:PolymorphicClass">
+            <xs:sequence>
+              <xs:element name="value2" type="xsd:string"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+
       <xsd:element name="NewOperationResponse">
         <xsd:complexType>
           <xsd:sequence>
@@ -19,6 +35,7 @@
       	<xsd:complexType>
       		<xsd:sequence>
       			<xsd:element name="out" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
+                        <xsd:element name="out2" type="tns:PolymorphicClass" minOccurs="0"></xsd:element>
       		</xsd:sequence>
       	</xsd:complexType>
       </xsd:element>

--- a/unittests/optionaltype_regular/test.wsdl
+++ b/unittests/optionaltype_regular/test.wsdl
@@ -9,20 +9,20 @@
         </xsd:complexType>
       </xsd:element>
 
-      <xs:complexType name="PolymorphicClass">
-        <xs:sequence>
-          <xs:element name="value" type="xsd:string"/>
-        </xs:sequence>
-      </xs:complexType>
-      <xs:complexType name="DerivedClass">
-        <xs:complexContent>
-          <xs:extension base="tns:PolymorphicClass">
-            <xs:sequence>
-              <xs:element name="value2" type="xsd:string"/>
-            </xs:sequence>
-          </xs:extension>
-        </xs:complexContent>
-      </xs:complexType>
+      <xsd:complexType name="PolymorphicClass">
+        <xsd:sequence>
+          <xsd:element name="value" type="xsd:string"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="DerivedClass">
+        <xsd:complexContent>
+          <xsd:extension base="tns:PolymorphicClass">
+            <xsd:sequence>
+              <xsd:element name="value2" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:extension>
+        </xsd:complexContent>
+      </xsd:complexType>
 
       <xsd:element name="NewOperationResponse">
         <xsd:complexType>

--- a/unittests/optionaltype_regular/testregularapi.cpp
+++ b/unittests/optionaltype_regular/testregularapi.cpp
@@ -41,4 +41,26 @@ void TestRegularApi::test()
     QCOMPARE(resp.hasValueForOut(), true);
 }
 
+void TestRegularApi::testPolymorphic()
+{
+    TNS__TestOperationResponse1 resp;
+    QCOMPARE(resp.out2(), (TNS__PolymorphicClass*)0);
+    QCOMPARE(resp.hasValueForOut2(), false);
+    TNS__PolymorphicClass value;
+    value.setValue(QString("newvalue"));
+    resp.setOut2(value);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("newvalue"));
+    QCOMPARE(resp.hasValueForOut2(), true);
+
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut2(derivedValue);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("derived"));
+    QCOMPARE(dynamic_cast<const TNS__DerivedClass*>(resp.out2())->value2(), QString("derived"));
+}
+
 QTEST_MAIN(TestRegularApi)

--- a/unittests/optionaltype_regular/testregularapi.h
+++ b/unittests/optionaltype_regular/testregularapi.h
@@ -36,6 +36,7 @@ public:
 
 private slots:
     void test();
+    void testPolymorphic();
 
 private:
 };


### PR DESCRIPTION
This now works for polymorphic classes as well. Tests have also been expanded for this.  Change the default name of the argument passed to the setter function. (Fix for _daylight and _timezone i MSVC-2017).

Revert the change in location of the "KODE::setDefaultIndentation" (use of .indent() and .unindent() before calling this will use the old indentation size).