### PR TITLE
Allow generating message without service or bindings

### DIFF
--- a/doc/CHANGES_1_8.txt
+++ b/doc/CHANGES_1_8.txt
@@ -40,3 +40,4 @@ WSDL parser / code generator changes, applying to both client and server side:
 * Added functionality to prevent downloading the same WSDL/XSD file twice in one run
 * Added "hasValueFor{MemberName}()" accessor function, for optional elements
 * Generated services now include soapVersion() and endpoint() accessors to match the setSoapVersion(...) and setEndpoint(...) mutators
+* Added support for generating messages for WSDL files without services or bindings

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_subdirectory(vidyo)
 add_subdirectory(ws_addressing_support)
 add_subdirectory(ws_usernametoken_support)
 add_subdirectory(empty_element_wsdl)
+add_subdirectory(ws_discovery_wsdl)
 
 # These need internet access
 add_subdirectory(webcalls)

--- a/unittests/ws_discovery_wsdl/CMakeLists.txt
+++ b/unittests/ws_discovery_wsdl/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(ws_discovery_wsdl)
+
+set(KSWSDL2CPP_OPTION -use-local-files-only)
+set(WSDL_FILES ws_discovery200504.wsdl)
+set(ws_discovery_wsdl_SRCS test_ws_discovery_wsdl.cpp wsdl_ws_discovery200504.cpp)
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${ws_discovery_wsdl_SRCS} )

--- a/unittests/ws_discovery_wsdl/schemas.xmlsoap.org/ws/2004/08/addressing
+++ b/unittests/ws_discovery_wsdl/schemas.xmlsoap.org/ws/2004/08/addressing
@@ -1,0 +1,149 @@
+﻿<?xml version="1.0"?>
+<!-- 
+Copyright © 2002-2004 BEA Systems Inc., International Business Machines Corporation, 
+Microsoft Corporation, Inc, SAP AG, and Sun Microsystems, Inc.. All rights reserved. 
+
+Permission to copy, display, perform, modify and distribute the WS-Addressing Specification, 
+and to authorize others to do the foregoing, in any medium without fee or royalty is hereby
+granted for the purpose of developing and evaluating the WS-Addressing Specification.
+
+BEA, IBM, Microsoft, SAP AG, and Sun Microsystems (collectively, the "Authors") each agree 
+to grant a license to third parties, under royalty-free  and otherwise reasonable, 
+non-discriminatory terms and conditions, to their respective essential patent claims that
+they deem necessary to implement the WS-Addressing Specification.
+
+DISCLAIMERS:
+
+THE WS-Addressing Specification IS PROVIDED "AS IS", AND THE AUTHORS MAKE NO REPRESENTATIONS
+OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE 
+CONTENTS OF THE WS-Addressing Specification IS SUITABLE FOR ANY PURPOSE; NOR THAT THE 
+IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, 
+TRADEMARKS OR OTHER RIGHTS.
+
+THE AUTHORS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL 
+DAMAGES ARISING OUT OF ANY USE OF THE WS-Addressing Specification OR THE PERFORMANCE OR 
+IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+You may remove these disclaimers from your modified versions of the WS-Addressing 
+Specification provided that you effectively disclaim all warranties and liabilities on behalf 
+of all copyright holders in the copies of any such modified versions you distribute.
+
+The name and trademarks of the Authors may NOT be used in any manner, including advertising 
+or publicity pertaining to the WS-Addressing Specification or its contents without specific, 
+written prior permission. Title to copyright in the WS-Addressing Specification will at all 
+times remain with the Authors.
+
+No other rights are granted by implication, estoppel or otherwise.
+
+-->
+<xs:schema targetNamespace="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" elementFormDefault="qualified" blockDefault="#all">
+  <!-- //////////////////// WS-Addressing //////////////////// -->
+  <!-- Endpoint reference -->
+  <xs:element name="EndpointReference" type="wsa:EndpointReferenceType"/>
+  <xs:complexType name="EndpointReferenceType">
+    <xs:sequence>
+      <xs:element name="Address" type="wsa:AttributedURI"/>
+      <xs:element name="ReferenceProperties" type="wsa:ReferencePropertiesType" minOccurs="0"/>
+      <xs:element name="ReferenceParameters" type="wsa:ReferenceParametersType" minOccurs="0"/>
+      <xs:element name="PortType" type="wsa:AttributedQName" minOccurs="0"/>
+      <xs:element name="ServiceName" type="wsa:ServiceNameType" minOccurs="0"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+					 If "Policy" elements from namespace "http://schemas.xmlsoap.org/ws/2002/12/policy#policy" are used, they must appear first (before any extensibility elements).
+					</xs:documentation>
+        </xs:annotation>
+      </xs:any>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="ReferencePropertiesType">
+    <xs:sequence>
+      <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferenceParametersType">
+    <xs:sequence>
+      <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ServiceNameType">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attribute name="PortName" type="xs:NCName"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- Message information header blocks -->
+  <xs:element name="MessageID" type="wsa:AttributedURI"/>
+  <xs:element name="RelatesTo" type="wsa:Relationship"/>
+  <xs:element name="To" type="wsa:AttributedURI"/>
+  <xs:element name="Action" type="wsa:AttributedURI"/>
+  <xs:element name="From" type="wsa:EndpointReferenceType"/>
+  <xs:element name="ReplyTo" type="wsa:EndpointReferenceType"/>
+  <xs:element name="FaultTo" type="wsa:EndpointReferenceType"/>
+  <xs:complexType name="Relationship">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attribute name="RelationshipType" type="xs:QName" use="optional"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="RelationshipTypeValues">
+    <xs:restriction base="xs:QName">
+      <xs:enumeration value="wsa:Reply"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <!--
+    June 19, 2007: The ReplyAfter element is deprecated. The name of this element does not match the
+    name (RetryAfter) used in the specification (http://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/).
+  -->
+  <xs:element name="ReplyAfter" type="wsa:ReplyAfterType"/>
+  <xs:complexType name="ReplyAfterType">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:anyAttribute namespace="##other"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!--
+    June 19, 2007: The RetryAfter element has been added to be consistent with the specification
+    (http://www.w3.org/Submission/2004/SUBM-ws-addressing-20040810/).
+  -->
+  <xs:element name="RetryAfter" type="wsa:RetryAfterType"/>
+  <xs:complexType name="RetryAfterType">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:anyAttribute namespace="##other"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="FaultSubcodeValues">
+    <xs:restriction base="xs:QName">
+      <xs:enumeration value="wsa:InvalidMessageInformationHeader"/>
+      <xs:enumeration value="wsa:MessageInformationHeaderRequired"/>
+      <xs:enumeration value="wsa:DestinationUnreachable"/>
+      <xs:enumeration value="wsa:ActionNotSupported"/>
+      <xs:enumeration value="wsa:EndpointUnavailable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attribute name="Action" type="xs:anyURI"/>
+  <!-- Common declarations and definitions -->
+  <xs:complexType name="AttributedQName">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AttributedURI">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>

--- a/unittests/ws_discovery_wsdl/schemas.xmlsoap.org/ws/2005/04/discovery/ws-discovery.xsd
+++ b/unittests/ws_discovery_wsdl/schemas.xmlsoap.org/ws/2005/04/discovery/ws-discovery.xsd
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright Notice
+
+(c) 2004-2005 Microsoft Corporation, Inc. All rights reserved.
+
+Permission to copy, display, perform, modify and distribute the 
+WS-Discovery Specification (the "Specification", which includes 
+WSDL and schema documents), and to authorize others to do the 
+foregoing, in any medium without fee or royalty is hereby granted 
+for the purpose of developing and evaluating the Specification.
+
+BEA Systems, Canon, Intel, Microsoft, and webMethods, Inc. 
+(collectively, the "Co-Developers") each agree to grant a license 
+to third parties, under royalty-free and other reasonable, 
+non-discriminatory terms and conditions, to their respective 
+essential Licensed Claims, which reasonable, non-discriminatory 
+terms and conditions may include, for example, but are not limited 
+to, an affirmation  of the obligation to grant reciprocal licenses 
+under any of the licensee's patents that are necessary to implement 
+the Specification.  
+
+DISCLAIMERS:
+
+THE SPECIFICATION IS PROVIDED "AS IS," AND THE CO-DEVELOPERS MAKE 
+NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, 
+BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS 
+OF THE SPECIFICATION ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE 
+IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY 
+PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+THE CO-DEVELOPERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, 
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY 
+USE OF THE SPECIFICATION OR THE PERFORMANCE OR IMPLEMENTATION OF 
+THE CONTENTS THEREOF.
+
+You may remove these disclaimers from your modified versions of the 
+Specification provided that you effectively disclaim all warranties 
+and liabilities on behalf of all Co-developers and any copyright 
+holders in the copies of any such modified versions you distribute.
+
+The name and trademarks of the Co-developers may NOT be used in any 
+manner, including advertising or publicity pertaining to the 
+Specification or its contents without specific, written prior 
+permission. Title to copyright in the Specification will at all 
+times remain with Microsoft.
+
+No other rights are granted by implication, estoppel or otherwise.
+
+-->
+<xs:schema
+    targetNamespace="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:tns="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    blockDefault="#all" >
+
+  <xs:import
+      namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+      schemaLocation="http://schemas.xmlsoap.org/ws/2004/08/addressing" />
+
+  <!-- //////////////////// Discovery Messages //////////////////// -->
+
+  <xs:element name="Hello" type="tns:HelloType" />
+  <xs:complexType name="HelloType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:simpleType name="RelationshipType" >
+	<xs:restriction base="xs:QName" >
+	  <xs:enumeration value="tns:Suppression" />
+	</xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="OpenRelationshipType" >
+    <xs:union memberTypes="tns:RelationshipType xs:QName" />
+  </xs:simpleType>
+    
+  <xs:element name="Bye" type="tns:ByeType" />
+  <xs:complexType name="ByeType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Probe" type="tns:ProbeType" />
+  <xs:complexType name="ProbeType" >
+    <xs:sequence>
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="ProbeMatches" type="tns:ProbeMatchesType" />
+  <xs:complexType name="ProbeMatchesType" >
+    <xs:sequence>
+      <xs:element name="ProbeMatch"
+                  type="tns:ProbeMatchType"
+                  minOccurs="0"
+                  maxOccurs="unbounded" >
+      </xs:element>
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+  <xs:complexType name="ProbeMatchType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Resolve" type="tns:ResolveType" />
+  <xs:complexType name="ResolveType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="ResolveMatches" type="tns:ResolveMatchesType" />
+  <xs:complexType name="ResolveMatchesType" >
+    <xs:sequence>
+      <xs:element name="ResolveMatch" 
+                  type="tns:ResolveMatchType"
+                  minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+  <xs:complexType name="ResolveMatchType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Types" type="tns:QNameListType" />
+  <xs:simpleType name="QNameListType" >
+    <xs:list itemType="xs:QName" />
+  </xs:simpleType>
+
+  <xs:element name="Scopes" type="tns:ScopesType" />
+  <xs:complexType name="ScopesType" >
+    <xs:simpleContent>
+      <xs:extension base="tns:UriListType" >
+        <xs:attribute name="MatchBy" type="xs:anyURI" />
+        <xs:anyAttribute namespace="##other" processContents="lax" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="XAddrs" type="tns:UriListType" />
+  <xs:simpleType name="UriListType" >
+    <xs:list itemType="xs:anyURI" />
+  </xs:simpleType>
+
+  <xs:element name="MetadataVersion" type="xs:unsignedInt" />
+
+  <!-- //////////////////// Faults //////////////////// -->
+
+  <xs:simpleType name="FaultCodeType" >
+	<xs:restriction base="xs:QName" >
+	  <xs:enumeration value="tns:MatchingRuleNotSupported" />
+	</xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FaultCodeOpenType" >
+    <xs:union memberTypes="tns:FaultCodeType xs:QName" />
+  </xs:simpleType>
+
+  <xs:element name="SupportedMatchingRules" type="tns:UriListType" />
+
+  <!-- //////////////////// Compact Signature //////////////////// -->
+
+  <xs:attribute name="Id" type="xs:ID"/>
+
+  <xs:element name="Security" type="tns:SecurityType" />
+  <xs:complexType name="SecurityType" >
+    <xs:sequence>
+      <xs:element ref="tns:Sig" minOccurs="0" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType> 
+
+  <xs:element name="Sig" type="tns:SigType" />
+  <xs:complexType name="SigType" >
+    <xs:sequence>
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="Scheme" type="xs:anyURI" use="required" />
+    <xs:attribute name="KeyId" type="xs:base64Binary" />
+    <xs:attribute name="Refs" type="xs:IDREFS" use="required" />
+    <xs:attribute name="Sig" type="xs:base64Binary" use="required" />
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType> 
+
+  <!-- //////////////////// General Headers //////////////////// -->
+
+  <xs:element name="AppSequence" type="tns:AppSequenceType" />
+  <xs:complexType name="AppSequenceType" >
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType" >
+        <xs:attribute name="InstanceId"
+                      type="xs:unsignedInt"
+                      use="required" />
+        <xs:attribute name="SequenceId" type="xs:anyURI" />
+        <xs:attribute name="MessageNumber"
+                      type="xs:unsignedInt"
+                      use="required" />
+        <xs:anyAttribute namespace="##other" processContents="lax" />
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
+++ b/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
@@ -1,0 +1,142 @@
+/****************************************************************************
+** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "wsdl_ws_discovery200504.h"
+#include "httpserver_p.h"
+#include "KDSoapMessageReader_p.h"
+#include <QtTest/QtTest>
+
+// Apperently the original file is not available anymore: http://schemas.xmlsoap.org/ws/2005/04/discovery/ws-discovery.wsdl
+// However it is available via: https://web.archive.org/web/20070225062601/http://schemas.xmlsoap.org/ws/2005/04/discovery/ws-discovery.wsdl
+
+using namespace KDSoapUnitTestHelpers;
+
+class WSDiscoveryTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void testGeneratingProbe()
+    {
+        // Types
+        QStringList typeList;
+        typeList << "i:PrintBasic"; //namespace: http://printer.example.org/2003/imaging
+        TNS__QNameListType types;
+        types.setEntries(typeList);
+
+        // Scopes
+        QStringList uriStringList;
+        uriStringList << "ldap:///ou=engineering,o=examplecom,c=us";
+        TNS__UriListType uriList;
+        uriList.setEntries(uriStringList);
+        TNS__ScopesType scopes;
+        scopes.setValue(uriList);
+        scopes.setMatchBy("http://schemas.xmlsoap.org/ws/2005/04/discovery/ldap");
+
+        // Probe
+        TNS__ProbeType probe;
+        probe.setTypes(types);
+        probe.setScopes(scopes);
+
+        // Check what we sent
+        QByteArray expectedRequestXml =
+                QByteArray("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                           "<n1:Probe"
+                           " xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\""
+                           " xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+                           " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+                           " xmlns:soap-enc=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                           " xmlns:n1=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\">"
+                           "<n1:Types>i:PrintBasic</n1:Types>"
+                           "<n1:Scopes MatchBy=\"http://schemas.xmlsoap.org/ws/2005/04/discovery/ldap\">"
+                           "ldap:///ou=engineering,o=examplecom,c=us"
+                           "</n1:Scopes>"
+                           "</n1:Probe>");
+
+        KDSoapValue value = probe.serialize("Probe");
+        value.setNamespaceUri("http://schemas.xmlsoap.org/ws/2005/04/discovery");
+        QVERIFY(xmlBufferCompare(value.toXml(), expectedRequestXml));
+    }
+
+    void testReceivingProbe()
+    {
+        QByteArray incommingXmlData = QByteArray(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    "<s:Envelope"
+                    " xmlns:a=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\""
+                    " xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\""
+                    " xmlns:i=\"http://printer.example.org/2003/imaging\""
+                    " xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\" >"
+                    "<s:Body>"
+                    "<d:ProbeMatches>"
+                    "<d:ProbeMatch>"
+                    "<a:EndpointReference>"
+                    "<a:Address>"
+                    "uuid:98190dc2-0890-4ef8-ac9a-5940995e6119"
+                    "</a:Address>"
+                    "</a:EndpointReference>"
+                    "<d:Types>i:PrintBasic i:PrintAdvanced</d:Types>"
+                    "<d:Scopes>"
+                    "ldap:///ou=engineering,o=examplecom,c=us "
+                    "ldap:///ou=floor1,ou=b42,ou=anytown,o=examplecom,c=us "
+                    "http://itdept/imaging/deployment/2004-12-04"
+                    "</d:Scopes>"
+                    "<d:XAddrs>http://prn-example/PRN42/b42-1668-a</d:XAddrs>"
+                    "<d:MetadataVersion>75965</d:MetadataVersion>"
+                    "</d:ProbeMatch>"
+                    "</d:ProbeMatches>"
+                    "</s:Body>"
+                    "</s:Envelope>");
+
+        KDSoapMessage replyMessage;
+        KDSoapHeaders replyHeaders;
+
+        KDSoapMessageReader reader;
+        reader.xmlToMessage(incommingXmlData, &replyMessage, 0, &replyHeaders, KDSoap::SOAP1_2);
+
+        TNS__ProbeMatchesType probeMatches;
+        probeMatches.deserialize(replyMessage);
+
+        const QList< TNS__ProbeMatchType >& probeMatchList = probeMatches.probeMatch();
+        QCOMPARE(probeMatchList.size(), 1);
+        const TNS__ProbeMatchType& probeMatch = probeMatchList.value(0);
+        QCOMPARE(probeMatch.endpointReference().address(), QString("uuid:98190dc2-0890-4ef8-ac9a-5940995e6119"));
+        const QStringList& typeList = probeMatch.types().entries();
+        QCOMPARE(typeList.size(), 2);
+        QCOMPARE(typeList.value(0), QString("i:PrintBasic"));
+        QCOMPARE(typeList.value(1), QString("i:PrintAdvanced"));
+        const QStringList& scopeList = probeMatch.scopes().value().entries();
+        QCOMPARE(scopeList.size(), 3);
+        QCOMPARE(scopeList.value(0), QString("ldap:///ou=engineering,o=examplecom,c=us"));
+        QCOMPARE(scopeList.value(1), QString("ldap:///ou=floor1,ou=b42,ou=anytown,o=examplecom,c=us"));
+        QCOMPARE(scopeList.value(2), QString("http://itdept/imaging/deployment/2004-12-04"));
+        const QStringList& xaddrList = probeMatch.xAddrs().entries();
+        QCOMPARE(xaddrList.size(), 1);
+        QCOMPARE(xaddrList.value(0), QString("http://prn-example/PRN42/b42-1668-a"));
+        QCOMPARE(probeMatch.metadataVersion(), 75965);
+    }
+};
+
+QTEST_MAIN(WSDiscoveryTest)
+
+#include "test_ws_discovery_wsdl.moc"

--- a/unittests/ws_discovery_wsdl/ws_discovery200504.wsdl
+++ b/unittests/ws_discovery_wsdl/ws_discovery200504.wsdl
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright Notice
+
+(c) 2004-2005 Microsoft Corporation, Inc. All rights reserved.
+
+Permission to copy, display, perform, modify and distribute the 
+WS-Discovery Specification (the "Specification", which includes 
+WSDL and schema documents), and to authorize others to do the 
+foregoing, in any medium without fee or royalty is hereby granted 
+for the purpose of developing and evaluating the Specification.
+
+BEA Systems, Canon, Intel, Microsoft, and webMethods, Inc. 
+(collectively, the "Co-Developers") each agree to grant a license 
+to third parties, under royalty-free and other reasonable, 
+non-discriminatory terms and conditions, to their respective 
+essential Licensed Claims, which reasonable, non-discriminatory 
+terms and conditions may include, for example, but are not limited 
+to, an affirmation  of the obligation to grant reciprocal licenses 
+under any of the licensee's patents that are necessary to implement 
+the Specification.  
+
+DISCLAIMERS:
+
+THE SPECIFICATION IS PROVIDED "AS IS," AND THE CO-DEVELOPERS MAKE 
+NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, 
+BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS 
+OF THE SPECIFICATION ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE 
+IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY 
+PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+THE CO-DEVELOPERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, 
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY 
+USE OF THE SPECIFICATION OR THE PERFORMANCE OR IMPLEMENTATION OF 
+THE CONTENTS THEREOF.
+
+You may remove these disclaimers from your modified versions of the 
+Specification provided that you effectively disclaim all warranties 
+and liabilities on behalf of all Co-developers and any copyright 
+holders in the copies of any such modified versions you distribute.
+
+The name and trademarks of the Co-developers may NOT be used in any 
+manner, including advertising or publicity pertaining to the 
+Specification or its contents without specific, written prior 
+permission. Title to copyright in the Specification will at all 
+times remain with Microsoft.
+
+No other rights are granted by implication, estoppel or otherwise.
+
+-->
+<wsdl:definitions
+    targetNamespace="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:tns="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+
+  <wsdl:types>
+    <xs:schema>
+      <xs:import
+          namespace="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    schemaLocation
+    ="http://schemas.xmlsoap.org/ws/2005/04/discovery/ws-discovery.xsd"
+          />
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="HelloMsg" >
+    <wsdl:part name="body" element="tns:Hello" />
+  </wsdl:message>
+
+  <wsdl:message name="ByeMsg" >
+    <wsdl:part name="body" element="tns:Bye" />
+  </wsdl:message>
+
+  <wsdl:message name="ProbeMsg" >
+    <wsdl:part name="body" element="tns:Probe" />
+  </wsdl:message>
+
+  <wsdl:message name="ProbeMatchMsg" >
+    <wsdl:part name="body" element="tns:ProbeMatches" />
+  </wsdl:message>
+
+  <wsdl:message name="ResolveMsg" >
+    <wsdl:part name="body" element="tns:Resolve" />
+  </wsdl:message>
+
+  <wsdl:message name="ResolveMatchMsg" >
+    <wsdl:part name="body" element="tns:ResolveMatches" />
+  </wsdl:message>
+
+  <wsdl:portType name="TargetService" >
+    <wsdl:operation name="HelloOp" >
+      <wsdl:output message="tns:HelloMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/Hello"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ByeOp" >
+      <wsdl:output message="tns:ByeMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/Bye"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ProbeOp" >
+      <wsdl:input message="tns:ProbeMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ProbeMatchOp" >
+      <wsdl:output message="tns:ProbeMatchMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ResolveOp" >
+      <wsdl:input message="tns:ResolveMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/Resolve"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ResolveMatchOp" >
+      <wsdl:output message="tns:ResolveMatchMsg"
+      wsa:Action
+      ="http://schemas.xmlsoap.org/ws/2005/04/discovery/ResolveMatches"
+      />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <!-- If this portType is included in EndpointReference/Types, it
+       indicates the Target Service is a Discovery Proxy. Discovery
+       Proxies also implement tns:TargetService and optionally other
+       message exchanges defined elsewhere.
+  -->
+  <wsdl:portType name="DiscoveryProxy" />
+
+</wsdl:definitions>

--- a/unittests/ws_discovery_wsdl/ws_discovery_wsdl.pro
+++ b/unittests/ws_discovery_wsdl/ws_discovery_wsdl.pro
@@ -1,0 +1,9 @@
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += network xml
+SOURCES = test_ws_discovery_wsdl.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = ws_discovery200504.wsdl


### PR DESCRIPTION
Added support for generating messages for WSDL files without
services or bindings. Mainly to support WS-Discovery WSDL.

In an effort to create a [WS-Discovery client library](https://gitlab.com/caspermeijn/kdsoap-ws-discovery-client) I needed this change to generate the needed messages. 