### PR TITLE
List restriction to base

### DIFF
--- a/kdwsdl2cpp/CMakeLists.txt
+++ b/kdwsdl2cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ include(${QT_USE_FILE})
 remove_definitions(-DQT_NO_CAST_TO_ASCII -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-set(SOURCES
+set(SOURCES_LIB
   common/fileprovider.cpp
   common/messagehandler.cpp
   common/nsmanager.cpp
@@ -59,16 +59,19 @@ set(SOURCES
   src/converter_simpletype.cpp
   src/creator.cpp
   src/elementargumentserializer.cpp
-  src/main.cpp
   src/namemapper.cpp
   src/settings.cpp
   src/typemap.cpp
 )
 
-add_executable(kdwsdl2cpp ${SOURCES})
-target_link_libraries(kdwsdl2cpp ${QT_LIBRARIES})
+set(SOURCES_EXE src/main.cpp)
+
+add_library(kdwsdl2cpp_lib STATIC ${SOURCES_LIB})
+add_executable(kdwsdl2cpp ${SOURCES_EXE})
+
+target_link_libraries(kdwsdl2cpp kdwsdl2cpp_lib ${QT_LIBRARIES})
 
 install(TARGETS kdwsdl2cpp EXPORT "KDSoapTargets"
-  RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR}
-  BUNDLE DESTINATION .
+  DESTINATION ${INSTALL_RUNTIME_DIR}/${PROJECT_NAME_FOR_INSTALL}
+  COMPONENT devel
 )

--- a/kdwsdl2cpp/CMakeLists.txt
+++ b/kdwsdl2cpp/CMakeLists.txt
@@ -72,6 +72,6 @@ add_executable(kdwsdl2cpp ${SOURCES_EXE})
 target_link_libraries(kdwsdl2cpp kdwsdl2cpp_lib ${QT_LIBRARIES})
 
 install(TARGETS kdwsdl2cpp EXPORT "KDSoapTargets"
-  DESTINATION ${INSTALL_RUNTIME_DIR}/${PROJECT_NAME_FOR_INSTALL}
-  COMPONENT devel
+  RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR}
+  BUNDLE DESTINATION .
 )

--- a/kdwsdl2cpp/src/converter_simpletype.cpp
+++ b/kdwsdl2cpp/src/converter_simpletype.cpp
@@ -482,7 +482,7 @@ static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QStrin
     QString extendVariableName = variableName;
 
     if (!baseSimpleType.isNull()) {
-        if (baseSimpleType.subType() == 1) {
+        if (baseSimpleType.subType() == XSD::SimpleType::SubType::TypeList) {
             extendVariableName += ".entries()";
         }
         else {

--- a/kdwsdl2cpp/src/converter_simpletype.cpp
+++ b/kdwsdl2cpp/src/converter_simpletype.cpp
@@ -475,8 +475,7 @@ static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QStrin
     if (!baseSimpleType.isNull()) {
         if (baseSimpleType.subType() == XSD::SimpleType::SubType::TypeList) {
             extendedVariableName += ".entries()";
-        }
-        else {
+        } else {
             extendedVariableName += ".value()";
         }
     }

--- a/kdwsdl2cpp/src/converter_simpletype.cpp
+++ b/kdwsdl2cpp/src/converter_simpletype.cpp
@@ -229,16 +229,7 @@ void Converter::convertSimpleType(const XSD::SimpleType *type, const XSD::Simple
 
         newClass.addFunction(setter);
         newClass.addFunction(getter);
-<<<<<<< HEAD
-=======
 
-        // getLength
-        //KODE::Function length("length", "int");
-        //length.setBody("return entries().size();");
-        //length.setConst(true);
-
-        //newClass.addFunction(length);
->>>>>>> 8b9c1e6... fix code generate
     }
     break;
     case XSD::SimpleType::TypeUnion:
@@ -479,14 +470,14 @@ static QString escapeRegExp(const QString &str)
 
 static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QString &baseTypeName, const QString &variableName, KODE::Class &parentClass, const XSD::SimpleType &baseSimpleType)
 {
-    QString extendVariableName = variableName;
+    QString extendedVariableName = variableName;
 
     if (!baseSimpleType.isNull()) {
         if (baseSimpleType.subType() == XSD::SimpleType::SubType::TypeList) {
-            extendVariableName += ".entries()";
+            extendedVariableName += ".entries()";
         }
         else {
-            extendVariableName += ".value()";
+            extendedVariableName += ".value()";
         }
     }
 
@@ -518,13 +509,13 @@ static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QStrin
     }
 
     if (type->facetType() & XSD::SimpleType::LENGTH) {
-        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() == " + QString::number(type->facetLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendedVariableName + ".length() == " + QString::number(type->facetLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::MINLEN) {
-        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() >= " + QString::number(type->facetMinimumLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendedVariableName + ".length() >= " + QString::number(type->facetMinimumLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::MAXLEN) {
-        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() <= " + QString::number(type->facetMaximumLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendedVariableName + ".length() <= " + QString::number(type->facetMaximumLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::PATTERN) {
         if (baseTypeName == "QString") {

--- a/kdwsdl2cpp/src/converter_simpletype.cpp
+++ b/kdwsdl2cpp/src/converter_simpletype.cpp
@@ -7,7 +7,7 @@
 using namespace KWSDL;
 
 static QString escapeEnum(const QString &);
-static KODE::Code createRangeCheckCode(const XSD::SimpleType *, const QString &baseTypeName, const QString &, KODE::Class &);
+static KODE::Code createRangeCheckCode(const XSD::SimpleType *, const QString &baseTypeName, const QString &, KODE::Class &, const XSD::SimpleType &);
 
 void Converter::addVariableInitializer(KODE::MemberVariable &variable) const
 {
@@ -150,7 +150,8 @@ void Converter::convertSimpleType(const XSD::SimpleType *type, const XSD::Simple
             setter.addArgument(inputType + " value");
             KODE::Code setterBody;
             if (type->facetType() != XSD::SimpleType::NONE) {
-                setterBody += createRangeCheckCode(type, baseTypeName, "value", newClass);
+                const XSD::SimpleType baseSimpleType = simpleTypeList.simpleType(baseName);
+                setterBody += createRangeCheckCode(type, baseTypeName, "value", newClass, baseSimpleType);
                 setterBody.newLine();
                 setterBody += "if (!rangeOk)";
                 setterBody.indent();
@@ -228,6 +229,16 @@ void Converter::convertSimpleType(const XSD::SimpleType *type, const XSD::Simple
 
         newClass.addFunction(setter);
         newClass.addFunction(getter);
+<<<<<<< HEAD
+=======
+
+        // getLength
+        //KODE::Function length("length", "int");
+        //length.setBody("return entries().size();");
+        //length.setConst(true);
+
+        //newClass.addFunction(length);
+>>>>>>> 8b9c1e6... fix code generate
     }
     break;
     case XSD::SimpleType::TypeUnion:
@@ -466,8 +477,19 @@ static QString escapeRegExp(const QString &str)
     return reg;
 }
 
-static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QString &baseTypeName, const QString &variableName, KODE::Class &parentClass)
+static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QString &baseTypeName, const QString &variableName, KODE::Class &parentClass, const XSD::SimpleType &baseSimpleType)
 {
+    QString extendVariableName = variableName;
+
+    if (!baseSimpleType.isNull()) {
+        if (baseSimpleType.subType() == 1) {
+            extendVariableName += ".entries()";
+        }
+        else {
+            extendVariableName += ".value()";
+        }
+    }
+
     KODE::Code code;
     code += "bool rangeOk = true;";
     code.newLine();
@@ -496,13 +518,13 @@ static KODE::Code createRangeCheckCode(const XSD::SimpleType *type, const QStrin
     }
 
     if (type->facetType() & XSD::SimpleType::LENGTH) {
-        code += "rangeOk = rangeOk && (" + variableName + ".length() == " + QString::number(type->facetLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() == " + QString::number(type->facetLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::MINLEN) {
-        code += "rangeOk = rangeOk && (" + variableName + ".length() >= " + QString::number(type->facetMinimumLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() >= " + QString::number(type->facetMinimumLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::MAXLEN) {
-        code += "rangeOk = rangeOk && (" + variableName + ".length() <= " + QString::number(type->facetMaximumLength()) + ");";
+        code += "rangeOk = rangeOk && (" + extendVariableName + ".length() <= " + QString::number(type->facetMaximumLength()) + ");";
     }
     if (type->facetType() & XSD::SimpleType::PATTERN) {
         if (baseTypeName == "QString") {

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -5,7 +5,7 @@ set(QT_USE_QTTEST TRUE)
 
 include(${QT_USE_FILE})
 
-include_directories(../src/ ../src/KDSoapClient/ ../src/KDSoapServer/ ../testtools/)
+include_directories(../src/ ../src/KDSoapClient/ ../src/KDSoapServer/ ../testtools/ ../kdwsdl2cpp/ ../kdwsdl2cpp/src/ ../kdwsdl2cpp/libkode/ ../kdwsdl2cpp/common/ ../kdwsdl2cpp/schema/ ../kdwsdl2cpp/wsdl/)
 include(../KDSoapMacros.cmake)
 
 remove_definitions(-DQT_NO_CAST_FROM_ASCII)
@@ -89,3 +89,5 @@ add_subdirectory(enzo)
 add_subdirectory(fault_namespace)
 add_subdirectory(onvif_org_event)
 add_subdirectory(empty_list_wsdl)
+add_subdirectory(list_restriction)
+

--- a/unittests/list_restriction/CMakeLists.txt
+++ b/unittests/list_restriction/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(list_restriction)
+
+set(list_restriction_SRCS test_list_restriction.cpp)
+set(EXTRA_LIBS kdwsdl2cpp_lib)
+add_unittest(${list_restriction_SRCS}) 

--- a/unittests/list_restriction/test_list_restriction.cpp
+++ b/unittests/list_restriction/test_list_restriction.cpp
@@ -1,0 +1,358 @@
+#include <wsdl.h>
+
+#include <fileprovider.h>
+#include <messagehandler.h>
+#include <parsercontext.h>
+
+#include <converter.h>
+#include <creator.h>
+#include <settings.h>
+
+#include <compiler.h>
+//#include "wsdl_import_definition.h"
+#include "httpserver_p.h"
+
+#include <QtTest/QtTest>
+#include <QEventLoop>
+#include <QDebug>
+
+
+using namespace KDSoapUnitTestHelpers;
+
+class ListRestrictionTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void testGenerateCodeWithListRestriction()
+    {
+        QStringList generatedStrList;
+        QString generatedStr;
+        QString expectedStr = "rangeOk = rangeOk && (value.entries().length() == 3);";
+
+        const QByteArray srcXml = QByteArray("<definitions name=\"HelloService\""
+                                             "   targetNamespace=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns=\"http://schemas.xmlsoap.org/wsdl/\""
+                                             "   xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\""
+                                             "   xmlns:tns=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+                                             "   xmlns:test=\"urn:test\">"
+                                             "   <types>"
+                                             "    <xsd:schema targetNamespace=\"urn:test\""
+                                             "            xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >"
+                                             "            <xsd:import namespace=\"http://www.w3.org/2001/XMLSchema\"/>  "
+                                             "        <xsd:simpleType name=\"dArrayType\">"
+                                             "           <xsd:list itemType=\"xsd:double\"/>"
+                                             "        </xsd:simpleType>"
+                                             "        <xsd:simpleType name=\"d3ArrayType\">"
+                                             "            <xsd:restriction base=\"test:dArrayType\">"
+                                             "                <xsd:length value=\"3\"/>"
+                                             "            </xsd:restriction>"
+                                             "        </xsd:simpleType>"
+                                             "    </xsd:schema>"
+                                             "    </types>"
+                                             "   <message name=\"SayHelloRequest\">"
+                                             "      <part name=\"firstName\" type=\"test:d3ArrayType\"/>"
+                                             "   </message>"
+                                             "   <message name=\"SayHelloResponse\">"
+                                             "      <part name=\"greeting\" type=\"xsd:string\"/>"
+                                             "   </message>"
+                                             "   <portType name=\"Hello_PortType\">"
+                                             "      <operation name=\"sayHello\">"
+                                             "         <input message=\"tns:SayHelloRequest\"/>"
+                                             "         <output message=\"tns:SayHelloResponse\"/>"
+                                             "      </operation>"
+                                             "   </portType>"
+                                             "   <binding name=\"Hello_Binding\" type=\"tns:Hello_PortType\">"
+                                             "   <soap:binding style=\"rpc\""
+                                             "      transport=\"http://schemas.xmlsoap.org/soap/http\"/>"
+                                             "   <operation name=\"sayHello\">"
+                                             "      <soap:operation soapAction=\"sayHello\"/>"
+                                             "      <input>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </input>"
+                                             "      <output>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </output>"
+                                             "   </operation>"
+                                             "   </binding> "
+                                             "   <service name=\"Hello_Service\">"
+                                             "      <documentation>WSDL File for HelloService</documentation>"
+                                             "      <port binding=\"tns:Hello_Binding\" name=\"Hello_Port\">"
+                                             "         <soap:address"
+                                             "            location=\"http://www.examples.com/SayHello/\"/>"
+                                             "      </port>"
+                                             "   </service>"
+                                             "</definitions>");
+        QXmlInputSource source;
+        source.setData(srcXml);
+        QXmlSimpleReader reader;
+        reader.setFeature(QLatin1String("http://xml.org/sax/features/namespace-prefixes"), true);
+
+        QString errorMsg;
+        int errorLine, errorCol;
+        QDomDocument doc;
+        doc.setContent(&source, &reader, &errorMsg, &errorLine, &errorCol);
+
+        QDomElement element = doc.documentElement();
+        NSManager namespaceManager;
+        namespaceManager.setPrefix(QLatin1String("xml"), NSManager::xmlNamespace());
+
+        MessageHandler messageHandler;
+        ParserContext context;
+        context.setNamespaceManager(&namespaceManager);
+        context.setMessageHandler(&messageHandler);
+
+        KWSDL::Definitions definitions;
+        if (definitions.loadXML(&context, element)) {
+            definitions.fixUpDefinitions(/*&context, element*/);
+            KODE::Code::setDefaultIndentation(4);
+            KWSDL::WSDL wsdl;
+            wsdl.setDefinitions(definitions);
+            wsdl.setNamespaceManager(namespaceManager);
+            KWSDL::Converter converter;
+            converter.setWSDL(wsdl);
+
+            converter.convert();
+            foreach (auto elem, converter.classes()) {
+                if(elem.name() == QString("TEST__D3ArrayType")) {
+                    foreach(auto e_f,elem.functions()) {
+                        if(e_f.name() == QString("setValue")) {
+                            generatedStrList = e_f.body().split("\n");
+                            generatedStr = generatedStrList.at(2);
+                        }
+                    }
+                }
+            }
+        }
+        QCOMPARE(generatedStr, expectedStr);
+    }
+
+    void testGenerateCodeWithStringRestriction()
+    {
+        QStringList generatedStrList;
+        QString generatedStr;
+        QString expectedStr = "rangeOk = rangeOk && (value.value().length() == 3);";
+
+        const QByteArray srcXml = QByteArray("<definitions name=\"HelloService\""
+                                             "   targetNamespace=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns=\"http://schemas.xmlsoap.org/wsdl/\""
+                                             "   xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\""
+                                             "   xmlns:tns=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+                                             "   xmlns:test=\"urn:test\">"
+                                             "   <types>"
+                                             "    <xsd:schema targetNamespace=\"urn:test\""
+                                             "            xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >"
+                                             "            <xsd:import namespace=\"http://www.w3.org/2001/XMLSchema\"/>  "
+                                             "        <xsd:simpleType name=\"dArrayType\">"
+                                             "           <xsd:element type=\"xsd:string\" />"
+                                             "        </xsd:simpleType>"
+                                             "        <xsd:simpleType name=\"d3ArrayType\">"
+                                             "            <xsd:restriction base=\"test:dArrayType\">"
+                                             "                <xsd:length value=\"3\"/>"
+                                             "            </xsd:restriction>"
+                                             "        </xsd:simpleType>"
+                                             "    </xsd:schema>"
+                                             "    </types>"
+                                             "   <message name=\"SayHelloRequest\">"
+                                             "      <part name=\"firstName\" type=\"test:d3ArrayType\"/>"
+                                             "   </message>"
+                                             "   <message name=\"SayHelloResponse\">"
+                                             "      <part name=\"greeting\" type=\"xsd:string\"/>"
+                                             "   </message>"
+                                             "   <portType name=\"Hello_PortType\">"
+                                             "      <operation name=\"sayHello\">"
+                                             "         <input message=\"tns:SayHelloRequest\"/>"
+                                             "         <output message=\"tns:SayHelloResponse\"/>"
+                                             "      </operation>"
+                                             "   </portType>"
+                                             "   <binding name=\"Hello_Binding\" type=\"tns:Hello_PortType\">"
+                                             "   <soap:binding style=\"rpc\""
+                                             "      transport=\"http://schemas.xmlsoap.org/soap/http\"/>"
+                                             "   <operation name=\"sayHello\">"
+                                             "      <soap:operation soapAction=\"sayHello\"/>"
+                                             "      <input>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </input>"
+                                             "      <output>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </output>"
+                                             "   </operation>"
+                                             "   </binding> "
+                                             "   <service name=\"Hello_Service\">"
+                                             "      <documentation>WSDL File for HelloService</documentation>"
+                                             "      <port binding=\"tns:Hello_Binding\" name=\"Hello_Port\">"
+                                             "         <soap:address"
+                                             "            location=\"http://www.examples.com/SayHello/\"/>"
+                                             "      </port>"
+                                             "   </service>"
+                                             "</definitions>");
+        QXmlInputSource source;
+        source.setData(srcXml);
+        QXmlSimpleReader reader;
+        reader.setFeature(QLatin1String("http://xml.org/sax/features/namespace-prefixes"), true);
+
+        QString errorMsg;
+        int errorLine, errorCol;
+        QDomDocument doc;
+        doc.setContent(&source, &reader, &errorMsg, &errorLine, &errorCol);
+
+        QDomElement element = doc.documentElement();
+        NSManager namespaceManager;
+        namespaceManager.setPrefix(QLatin1String("xml"), NSManager::xmlNamespace());
+
+        MessageHandler messageHandler;
+        ParserContext context;
+        context.setNamespaceManager(&namespaceManager);
+        context.setMessageHandler(&messageHandler);
+
+        KWSDL::Definitions definitions;
+        if (definitions.loadXML(&context, element)) {
+            definitions.fixUpDefinitions(/*&context, element*/);
+            KODE::Code::setDefaultIndentation(4);
+            KWSDL::WSDL wsdl;
+            wsdl.setDefinitions(definitions);
+            wsdl.setNamespaceManager(namespaceManager);
+            KWSDL::Converter converter;
+            converter.setWSDL(wsdl);
+
+            converter.convert();
+            foreach (auto elem, converter.classes()) {
+                if(elem.name() == QString("TEST__D3ArrayType")) {
+                    foreach(auto e_f,elem.functions()) {
+                        if(e_f.name() == QString("setValue")) {
+                            generatedStrList = e_f.body().split("\n");
+                            generatedStr = generatedStrList.at(2);
+                        }
+                    }
+                }
+            }
+        }
+        QCOMPARE(generatedStr, expectedStr);
+    }
+
+    void testGenerateCodeWithXSDListRestriction()
+    {
+        QStringList generatedStrList;
+        QString generatedStr;
+        QString expectedStr = "rangeOk = rangeOk && (value.length() == 3);";
+
+        const QByteArray srcXml = QByteArray("<definitions name=\"HelloService\""
+                                             "   targetNamespace=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns=\"http://schemas.xmlsoap.org/wsdl/\""
+                                             "   xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\""
+                                             "   xmlns:tns=\"http://www.examples.com/wsdl/HelloService.wsdl\""
+                                             "   xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+                                             "   xmlns:test=\"urn:test\">"
+                                             "   <types>"
+                                             "    <xsd:schema targetNamespace=\"urn:test\""
+                                             "            xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >"
+                                             "            <xsd:import namespace=\"http://www.w3.org/2001/XMLSchema\"/>  "
+                                             "        <xsd:simpleType name=\"d3ArrayType\">"
+                                             "            <xsd:restriction base=\"xsd:string\">"
+                                             "                <xsd:length value=\"3\"/>"
+                                             "            </xsd:restriction>"
+                                             "        </xsd:simpleType>"
+                                             "    </xsd:schema>"
+                                             "    </types>"
+                                             "   <message name=\"SayHelloRequest\">"
+                                             "      <part name=\"firstName\" type=\"test:d3ArrayType\"/>"
+                                             "   </message>"
+                                             "   <message name=\"SayHelloResponse\">"
+                                             "      <part name=\"greeting\" type=\"xsd:string\"/>"
+                                             "   </message>"
+                                             "   <portType name=\"Hello_PortType\">"
+                                             "      <operation name=\"sayHello\">"
+                                             "         <input message=\"tns:SayHelloRequest\"/>"
+                                             "         <output message=\"tns:SayHelloResponse\"/>"
+                                             "      </operation>"
+                                             "   </portType>"
+                                             "   <binding name=\"Hello_Binding\" type=\"tns:Hello_PortType\">"
+                                             "   <soap:binding style=\"rpc\""
+                                             "      transport=\"http://schemas.xmlsoap.org/soap/http\"/>"
+                                             "   <operation name=\"sayHello\">"
+                                             "      <soap:operation soapAction=\"sayHello\"/>"
+                                             "      <input>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </input>"
+                                             "      <output>"
+                                             "         <soap:body"
+                                             "            encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\""
+                                             "            namespace=\"urn:examples:helloservice\""
+                                             "            use=\"encoded\"/>"
+                                             "      </output>"
+                                             "   </operation>"
+                                             "   </binding> "
+                                             "   <service name=\"Hello_Service\">"
+                                             "      <documentation>WSDL File for HelloService</documentation>"
+                                             "      <port binding=\"tns:Hello_Binding\" name=\"Hello_Port\">"
+                                             "         <soap:address"
+                                             "            location=\"http://www.examples.com/SayHello/\"/>"
+                                             "      </port>"
+                                             "   </service>"
+                                             "</definitions>");
+        QXmlInputSource source;
+        source.setData(srcXml);
+        QXmlSimpleReader reader;
+        reader.setFeature(QLatin1String("http://xml.org/sax/features/namespace-prefixes"), true);
+
+        QString errorMsg;
+        int errorLine, errorCol;
+        QDomDocument doc;
+        doc.setContent(&source, &reader, &errorMsg, &errorLine, &errorCol);
+
+        QDomElement element = doc.documentElement();
+        NSManager namespaceManager;
+        namespaceManager.setPrefix(QLatin1String("xml"), NSManager::xmlNamespace());
+
+        MessageHandler messageHandler;
+        ParserContext context;
+        context.setNamespaceManager(&namespaceManager);
+        context.setMessageHandler(&messageHandler);
+
+        KWSDL::Definitions definitions;
+        if (definitions.loadXML(&context, element)) {
+            definitions.fixUpDefinitions(/*&context, element*/);
+            KODE::Code::setDefaultIndentation(4);
+            KWSDL::WSDL wsdl;
+            wsdl.setDefinitions(definitions);
+            wsdl.setNamespaceManager(namespaceManager);
+            KWSDL::Converter converter;
+            converter.setWSDL(wsdl);
+
+            converter.convert();
+            foreach (auto elem, converter.classes()) {
+                if(elem.name() == QString("TEST__D3ArrayType")) {
+                    foreach(auto e_f,elem.functions()) {
+                        if(e_f.name() == QString("setValue")) {
+                            generatedStrList = e_f.body().split("\n");
+                            generatedStr = generatedStrList.at(2);
+                        }
+                    }
+                }
+            }
+        }
+        QCOMPARE(generatedStr, expectedStr);
+    }
+};
+
+QTEST_MAIN(ListRestrictionTest)
+
+#include "test_list_restriction.moc"

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -37,16 +37,17 @@ SUBDIRS = \
   encapsecurity \
   prefix_wsdl \
   vidyo \
-  list_restriction \
   empty_list_wsdl \
-  fault_namespace \
+  onvif_org_event \
   empty_element_wsdl \
+  fault_namespace \
   enzo \
   date_example \
   dv_terminalauth \
   test_calc \
   ws_addressing_support \
-  default_attribute_value_wsdl
+  ws_usernametoken_support \
+  list_restriction
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -37,16 +37,16 @@ SUBDIRS = \
   encapsecurity \
   prefix_wsdl \
   vidyo \
+  list_restriction \
   empty_list_wsdl \
-  onvif_org_event \
-  empty_element_wsdl \
   fault_namespace \
+  empty_element_wsdl \
   enzo \
   date_example \
   dv_terminalauth \
   test_calc \
   ws_addressing_support \
-  ws_usernametoken_support
+  default_attribute_value_wsdl
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl


### PR DESCRIPTION
For schema:
```xml
<xsd:simpleType name=dArrayType>
	<xsd:list itemType=xsd:double/>
</xsd:simpleType>

<xsd:simpleType name=d3ArrayType>
	<xsd:restriction base=test:dArrayType>
		<xsd:length value=3/>
	</xsd:restriction>
</xsd:simpleType>
```
when generating code, `kdwsdl2cpp` skips the call to the `entries()` method for `DArrayType`.
For example, `void D3ArrayType::setValue (const DArrayType & value)` instead of `"value.entries().length ()"` is generated by `"value.length()"`
```c++
void D3ArrayType::setValue( const DArrayType& value )
{
    bool rangeOk = true;

    rangeOk = rangeOk && (value.length() == 3);

    if (!rangeOk)
        qDebug( "Invalid range in D3ArrayType::setValue()" );

    mValue = value;
}
```