### PR TITLE
Fix for required polymorphic types

### DIFF
--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -260,9 +260,10 @@ QString Converter::generateMemberVariable(const QString &rawName, const QString 
     // member variable
     const QString storageType = usePointer ? pointerStorageType(typeName) : typeName;
     KODE::MemberVariable variable(rawName, storageType);
-    addVariableInitializer(variable);
     if (usePointer && !optional) {
         variable.setInitializer("new " + typeName);
+    } else {
+        addVariableInitializer(variable);
     }
     newClass.addMemberVariable(variable);
 

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -253,20 +253,23 @@ void Converter::convertComplexType(const XSD::ComplexType *type)
 // Called for each element and for each attribute of a complex type, as well as for the base class "value".
 QString Converter::generateMemberVariable(const QString &rawName, const QString &typeName, const QString &inputTypeName, KODE::Class &newClass, XSD::Attribute::AttributeUse use, bool usePointer, bool polymorphic)
 {
+    const bool optional = (use == XSD::Attribute::Optional);
+    const bool prohibited = (use == XSD::Attribute::Prohibited);
+    const KODE::Function::AccessSpecifier access = (prohibited) ? KODE::Function::Private : KODE::Function::Public;
+
     // member variable
     const QString storageType = usePointer ? pointerStorageType(typeName) : typeName;
     KODE::MemberVariable variable(rawName, storageType);
     addVariableInitializer(variable);
+    if (usePointer && !optional) {
+        variable.setInitializer("new " + typeName);
+    }
     newClass.addMemberVariable(variable);
 
     const QString variableName = QLatin1String("d_ptr->") + variable.name();
     const QString upperName = upperlize(rawName);
     const QString lowerName = lowerlize(rawName);
     const QString memberName = mNameMapper.escape(lowerName);
-
-    bool optional = (use == XSD::Attribute::Optional);
-    bool prohibited = (use == XSD::Attribute::Prohibited);
-    const KODE::Function::AccessSpecifier access = (prohibited) ? KODE::Function::Private : KODE::Function::Public;
 
     if (usePointer) {
         newClass.addInclude("QSharedPointer");

--- a/src/KDSoapClient/KDSoapPendingCall.cpp
+++ b/src/KDSoapClient/KDSoapPendingCall.cpp
@@ -60,7 +60,7 @@ static void debugHelper(const QByteArray &data, const QList<QNetworkReply::RawHe
 
         while (!reader.atEnd()) {
             reader.readNext();
-            if (!reader.isWhitespace()) {
+            if (!reader.hasError() && !reader.isWhitespace()) {
                 writer.writeCurrentToken(reader);
             }
         }

--- a/unittests/optionaltype_boost_optional/test.wsdl
+++ b/unittests/optionaltype_boost_optional/test.wsdl
@@ -8,6 +8,22 @@
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
+
+      <xsd:complexType name="PolymorphicClass">
+        <xsd:sequence>
+          <xsd:element name="value" type="xsd:string"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="DerivedClass">
+        <xsd:complexContent>
+          <xsd:extension base="tns:PolymorphicClass">
+            <xsd:sequence>
+              <xsd:element name="value2" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:extension>
+        </xsd:complexContent>
+      </xsd:complexType>
+
       <xsd:element name="NewOperationResponse">
         <xsd:complexType>
           <xsd:sequence>
@@ -19,6 +35,8 @@
       	<xsd:complexType>
       		<xsd:sequence>
       			<xsd:element name="out" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
+                        <xsd:element name="out2" type="tns:PolymorphicClass" minOccurs="0"></xsd:element>
+                        <xsd:element name="out3" type="tns:PolymorphicClass" minOccurs="1" maxOccurs="1"></xsd:element>
       		</xsd:sequence>
       	</xsd:complexType>
       </xsd:element>

--- a/unittests/optionaltype_boost_optional/testboostapi.cpp
+++ b/unittests/optionaltype_boost_optional/testboostapi.cpp
@@ -39,4 +39,42 @@ void TestBoostApi::test()
     QCOMPARE(*resp.out(), newVal);
 }
 
+void TestBoostApi::testPolymorphic()
+{
+    TNS__TestOperationResponse1 resp;
+    QCOMPARE(resp.out2(), (TNS__PolymorphicClass*)0);
+    QCOMPARE(resp.hasValueForOut2(), false);
+    TNS__PolymorphicClass value;
+    value.setValue(QString("newvalue"));
+    resp.setOut2(value);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("newvalue"));
+    QCOMPARE(resp.hasValueForOut2(), true);
+
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut2(derivedValue);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("derived"));
+    QCOMPARE(dynamic_cast<const TNS__DerivedClass*>(resp.out2())->value2(), QString("derived"));
+}
+
+void TestBoostApi::testSerialize()
+{
+    // TNS__TestOperationResponse1 has "out3" which is polymorphic AND non-optional
+    //    If "out3" is not initialized, then trying to serialize causes a crash.
+    //    Verify it doesn't crash.
+    TNS__TestOperationResponse1 resp;
+    resp.serialize("Test");
+    QCOMPARE(resp.out3().value(), QString());
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut3(derivedValue);
+    QCOMPARE(resp.out3().value(), QString("derived"));
+}
+
 QTEST_MAIN(TestBoostApi)

--- a/unittests/optionaltype_boost_optional/testboostapi.h
+++ b/unittests/optionaltype_boost_optional/testboostapi.h
@@ -36,6 +36,8 @@ public:
 
 private slots:
     void test();
+    void testPolymorphic();
+    void testSerialize();
 
 private:
 };

--- a/unittests/optionaltype_pointer/test.wsdl
+++ b/unittests/optionaltype_pointer/test.wsdl
@@ -8,6 +8,22 @@
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
+
+      <xsd:complexType name="PolymorphicClass">
+        <xsd:sequence>
+          <xsd:element name="value" type="xsd:string"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="DerivedClass">
+        <xsd:complexContent>
+          <xsd:extension base="tns:PolymorphicClass">
+            <xsd:sequence>
+              <xsd:element name="value2" type="xsd:string"/>
+            </xsd:sequence>
+          </xsd:extension>
+        </xsd:complexContent>
+      </xsd:complexType>
+
       <xsd:element name="NewOperationResponse">
         <xsd:complexType>
           <xsd:sequence>
@@ -19,7 +35,9 @@
       	<xsd:complexType>
       		<xsd:sequence>
       			<xsd:element name="out" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
-      			<xsd:element name="outOptionalArray" type="xsd:integer" maxOccurs="unbounded" minOccurs="0"></xsd:element>
+                        <xsd:element name="outOptionalArray" type="xsd:integer" maxOccurs="unbounded" minOccurs="0"></xsd:element>
+                        <xsd:element name="out2" type="tns:PolymorphicClass" minOccurs="0"></xsd:element>
+                        <xsd:element name="out3" type="tns:PolymorphicClass" minOccurs="1" maxOccurs="1"></xsd:element>
       		</xsd:sequence>
       	</xsd:complexType>
       </xsd:element>

--- a/unittests/optionaltype_pointer/testpointerapi.cpp
+++ b/unittests/optionaltype_pointer/testpointerapi.cpp
@@ -54,4 +54,42 @@ void TestPointerApi::testOptionalArray()
     QCOMPARE(valIn, *resp2.outOptionalArray());
 }
 
+void TestPointerApi::testPolymorphic()
+{
+    TNS__TestOperationResponse1 resp;
+    QCOMPARE(resp.out2(), (TNS__PolymorphicClass*)0);
+    QCOMPARE(resp.hasValueForOut2(), false);
+    TNS__PolymorphicClass value;
+    value.setValue(QString("newvalue"));
+    resp.setOut2(value);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("newvalue"));
+    QCOMPARE(resp.hasValueForOut2(), true);
+
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut2(derivedValue);
+    QVERIFY(resp.out2());
+    QCOMPARE(resp.out2()->value(), QString("derived"));
+    QCOMPARE(dynamic_cast<const TNS__DerivedClass*>(resp.out2())->value2(), QString("derived"));
+}
+
+void TestPointerApi::testSerialize()
+{
+    // TNS__TestOperationResponse1 has "out3" which is polymorphic AND non-optional
+    //    If "out3" is not initialized, then trying to serialize causes a crash.
+    //    Verify it doesn't crash.
+    TNS__TestOperationResponse1 resp;
+    resp.serialize("Test");
+    QCOMPARE(resp.out3().value(), QString());
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut3(derivedValue);
+    QCOMPARE(resp.out3().value(), QString("derived"));
+}
+
 QTEST_MAIN(TestPointerApi)

--- a/unittests/optionaltype_pointer/testpointerapi.h
+++ b/unittests/optionaltype_pointer/testpointerapi.h
@@ -37,6 +37,8 @@ public:
 private slots:
     void test();
     void testOptionalArray();
+    void testPolymorphic();
+    void testSerialize();
 
 private:
 };

--- a/unittests/optionaltype_regular/test.wsdl
+++ b/unittests/optionaltype_regular/test.wsdl
@@ -36,6 +36,7 @@
       		<xsd:sequence>
       			<xsd:element name="out" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
                         <xsd:element name="out2" type="tns:PolymorphicClass" minOccurs="0"></xsd:element>
+                        <xsd:element name="out3" type="tns:PolymorphicClass" minOccurs="1" maxOccurs="1"></xsd:element>
       		</xsd:sequence>
       	</xsd:complexType>
       </xsd:element>

--- a/unittests/optionaltype_regular/testregularapi.cpp
+++ b/unittests/optionaltype_regular/testregularapi.cpp
@@ -61,4 +61,20 @@ void TestRegularApi::testPolymorphic()
     QCOMPARE(dynamic_cast<const TNS__DerivedClass*>(resp.out2())->value2(), QString("derived"));
 }
 
+void TestRegularApi::testSerialize()
+{
+    // TNS__TestOperationResponse1 has "out3" which is polymorphic AND non-optional
+    //    If "out3" is not initialied, then trying to serialize causes a crash.
+    //    Verify it doesn't crash. 
+    TNS__TestOperationResponse1 resp;
+    resp.serialize("Test");
+    QVERIFY(true);
+
+    TNS__DerivedClass derivedValue;
+    derivedValue.setValue("derived");
+    derivedValue.setValue2("derived");
+    resp.setOut3(derivedValue);
+    QCOMPARE(resp.out3().value(), QString("derived"));
+}
+
 QTEST_MAIN(TestRegularApi)

--- a/unittests/optionaltype_regular/testregularapi.cpp
+++ b/unittests/optionaltype_regular/testregularapi.cpp
@@ -64,11 +64,11 @@ void TestRegularApi::testPolymorphic()
 void TestRegularApi::testSerialize()
 {
     // TNS__TestOperationResponse1 has "out3" which is polymorphic AND non-optional
-    //    If "out3" is not initialied, then trying to serialize causes a crash.
+    //    If "out3" is not initialized, then trying to serialize causes a crash.
     //    Verify it doesn't crash. 
     TNS__TestOperationResponse1 resp;
     resp.serialize("Test");
-    QVERIFY(true);
+    QCOMPARE(resp.out3().value(), QString());
 
     TNS__DerivedClass derivedValue;
     derivedValue.setValue("derived");

--- a/unittests/optionaltype_regular/testregularapi.h
+++ b/unittests/optionaltype_regular/testregularapi.h
@@ -37,6 +37,7 @@ public:
 private slots:
     void test();
     void testPolymorphic();
+    void testSerialize();
 
 private:
 };


### PR DESCRIPTION
When a generated class containing a required (minOccurs=1) polymorphic variable, and that variable was not specified, then the serialize() function would crash (dereferencing a null pointer). This fixes the crash.