### PR TITLE
KDDateTime: added a QVariant conversion operator

### DIFF
--- a/doc/CHANGES_1_8.txt
+++ b/doc/CHANGES_1_8.txt
@@ -20,6 +20,7 @@ Client-side:
 * Rename the missing KDSoapJob::returnHeaders() to KDSoapJob::replyHeaders(), and provide an implementation
 * Make KDSoapClientInterface::soapVersion() const
 * Add lastFaultCode() for error handling after sync calls. Same as lastErrorCode() but it returns a QString rather than an int.
+* Add conversion operator from KDDateTime to QVariant to void implicit conversion to base QDateTime (github issue #123).
 
 Server-side:
 ============

--- a/src/KDSoapClient/KDDateTime.cpp
+++ b/src/KDSoapClient/KDDateTime.cpp
@@ -57,6 +57,11 @@ KDDateTime::~KDDateTime()
 {
 }
 
+KDDateTime::operator QVariant() const
+{
+    return QVariant::fromValue(*this);
+}
+
 QString KDDateTime::timeZone() const
 {
     return d->mTimeZone;

--- a/src/KDSoapClient/KDDateTime.h
+++ b/src/KDSoapClient/KDDateTime.h
@@ -51,6 +51,13 @@ public:
     ~KDDateTime();
 
     /**
+     * Converts the KDDateTime to QVariant, to avoid implicit conversion
+     * to base QDateTime.
+     * \since 1.8
+     */
+    operator QVariant() const;
+
+    /**
      * Returns the time zone set by setTimeZone.
      */
     QString timeZone() const;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -91,3 +91,4 @@ add_subdirectory(onvif_org_event)
 add_subdirectory(empty_list_wsdl)
 add_subdirectory(list_restriction)
 
+add_subdirectory(kddatetime)

--- a/unittests/kddatetime/CMakeLists.txt
+++ b/unittests/kddatetime/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(kddatetime_SRCS kddatetime.cpp)
+add_unittest(${kddatetime_SRCS})

--- a/unittests/kddatetime/kddatetime.cpp
+++ b/unittests/kddatetime/kddatetime.cpp
@@ -1,0 +1,56 @@
+/****************************************************************************
+** Copyright (C) 2010-2018 Klaralvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "KDSoapValue.h"
+#include "KDDateTime.h"
+#include <QTest>
+
+class KDDateTimeTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+
+    void testQVariantArgConversion()
+    {
+        KDDateTime inputDateTime(QDateTime::currentDateTimeUtc());
+        inputDateTime.setTimeZone("Z");
+
+        // Add to the value list, which implicitly constructs a QVariant
+        // from the KDDateTime...
+        KDSoapValueList list;
+        list.addArgument("Timestamp", inputDateTime);
+
+        /// Retrieve the KDDateTime from QVariant
+        KDDateTime outputDateTime = list.child("Timestamp").value().value<KDDateTime>();
+
+        QCOMPARE(inputDateTime, outputDateTime);
+
+        QCOMPARE(inputDateTime.timeZone(), outputDateTime.timeZone());
+        QCOMPARE(inputDateTime.toDateString(), outputDateTime.toDateString());
+    }
+};
+
+QTEST_MAIN(KDDateTimeTest)
+
+#include "kddatetime.moc"
+

--- a/unittests/kddatetime/kddatetime.pro
+++ b/unittests/kddatetime/kddatetime.pro
@@ -1,0 +1,12 @@
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += network xml
+SOURCES = kddatetime.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = 
+
+OTHER_FILES = $$KDWSDL
+LIBS        += -L$${TOP_BUILD_DIR}/lib

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -37,6 +37,7 @@ SUBDIRS = \
   encapsecurity \
   prefix_wsdl \
   vidyo \
+  kddatetime \
   empty_list_wsdl \
   onvif_org_event \
   empty_element_wsdl \


### PR DESCRIPTION
This prevents the QVariant from being implicitly constructed using the base QDateTime, which leads to the loss of information (#123).