### PR TITLE
Fixed ambiguous class name error with Qt custom namespace.

### DIFF
--- a/kdwsdl2cpp/schema/parser.h
+++ b/kdwsdl2cpp/schema/parser.h
@@ -32,7 +32,10 @@
 #include "annotation.h"
 #include <kode_export.h>
 
+QT_BEGIN_NAMESPACE
 class QUrl;
+QT_END_NAMESPACE
+
 class ParserContext;
 
 namespace XSD

--- a/src/KDSoapServer/KDSoapServerObjectInterface.h
+++ b/src/KDSoapServer/KDSoapServerObjectInterface.h
@@ -33,7 +33,10 @@
 #include <QIODevice>
 
 class KDSoapServerSocket;
+
+QT_BEGIN_NAMESPACE
 class QAbstractSocket;
+QT_END_NAMESPACE
 
 /**
  * Base class for server objects, i.e. objects implementing the methods


### PR DESCRIPTION
As described in https://github.com/KDAB/KDSoap/issues/171

Moved this single commit to a different branch just to make the request a bit cleaner.