### PR TITLE
addressing: Add namespace selection

### DIFF
--- a/doc/CHANGES_1_9.txt
+++ b/doc/CHANGES_1_9.txt
@@ -3,6 +3,7 @@ General:
 
 Client-side:
 ============
+* Add support for selecting WS-Addressing namespace for send messages
 
 Server-side:
 ============

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -43,6 +43,7 @@ public:
     QVector<KDSoapMessageRelationship::Relationship> relationships;   // Indicates relationships to prior messages, could be included to facilitate longer running message exchanges.
     KDSoapValueList referenceParameters; // Equivalent of the reference parameters object from the endpoint reference within WSDL file
     KDSoapValueList metadata; // Holding metadata information
+    KDSoapMessageAddressingProperties::KDSoapAddressingNamespace addressingNamespace = KDSoapMessageAddressingProperties::Addressing200508;
 };
 
 KDSoapMessageAddressingProperties::KDSoapMessageAddressingProperties()
@@ -200,21 +201,32 @@ void KDSoapMessageAddressingProperties::addMetadata(const KDSoapValue &metadata)
     }
 }
 
+KDSoapMessageAddressingProperties::KDSoapAddressingNamespace KDSoapMessageAddressingProperties::addressingNamespace() const
+{
+    return d->addressingNamespace;
+}
+
+void KDSoapMessageAddressingProperties::setAddressingNamespace(KDSoapMessageAddressingProperties::KDSoapAddressingNamespace addressingNamespace)
+{
+    d->addressingNamespace = addressingNamespace;
+}
+
 KDSoapMessageAddressingProperties::~KDSoapMessageAddressingProperties()
 {
 }
 
-QString KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::KDSoapAddressingPredefinedAddress address)
+QString KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::KDSoapAddressingPredefinedAddress address, KDSoapAddressingNamespace addressingNamespace)
 {
+    const QString addressingNS = addressingNamespaceToString(addressingNamespace);
     switch (address) {
     case Anonymous:
-        return QLatin1String("http://www.w3.org/2005/08/addressing/anonymous");
+        return addressingNS + QLatin1String("/anonymous");
     case None:
-        return QLatin1String("http://www.w3.org/2005/08/addressing/none");
+        return addressingNS + QLatin1String("/none");
     case Reply:
-        return QLatin1String("http://www.w3.org/2005/08/addressing/reply");
+        return addressingNS + QLatin1String("/reply");
     case Unspecified:
-        return QLatin1String("http://www.w3.org/2005/08/addressing/unspecified");
+        return addressingNS + QLatin1String("/unspecified");
     default:
         Q_ASSERT(false); // should never happen
         return QString();
@@ -229,9 +241,26 @@ bool KDSoapMessageAddressingProperties::isWSAddressingNamespace(const QString &n
             namespaceUri == KDSoapNamespaceManager::soapMessageAddressing200408();
 }
 
-static void writeAddressField(QXmlStreamWriter &writer, const QString &address)
+QString KDSoapMessageAddressingProperties::addressingNamespaceToString(KDSoapAddressingNamespace addressingNamespace)
 {
-    writer.writeStartElement(KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("Address"));
+    switch (addressingNamespace) {
+    case Addressing200303:
+        return KDSoapNamespaceManager::soapMessageAddressing200303();
+    case Addressing200403:
+        return KDSoapNamespaceManager::soapMessageAddressing200403();
+    case Addressing200408:
+        return KDSoapNamespaceManager::soapMessageAddressing200408();
+    case Addressing200508:
+        return KDSoapNamespaceManager::soapMessageAddressing();
+    default:
+        Q_ASSERT(false); // should never happen
+        return QString();
+    }
+}
+
+static void writeAddressField(QXmlStreamWriter &writer, const QString &addressingNS, const QString &address)
+{
+    writer.writeStartElement(addressingNS, QLatin1String("Address"));
     writer.writeCharacters(address);
     writer.writeEndElement();
 }
@@ -246,10 +275,8 @@ static void writeKDSoapValueVariant(QXmlStreamWriter &writer, const KDSoapValue 
                  "value because it could not be converted into a QString");
 }
 
-static void writeKDSoapValueListHierarchy(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const KDSoapValueList &values)
+static void writeKDSoapValueListHierarchy(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const QString &addressingNS, const KDSoapValueList &values)
 {
-    const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
-
     Q_FOREACH (const KDSoapValue &value, values)  {
         const QString topLevelName = value.name();
         writer.writeStartElement(addressingNS, topLevelName);
@@ -257,7 +284,7 @@ static void writeKDSoapValueListHierarchy(KDSoapNamespacePrefixes &namespacePref
         if (value.childValues().isEmpty()) {
             writeKDSoapValueVariant(writer, value);
         } else {
-            writeKDSoapValueListHierarchy(namespacePrefixes, writer, value.childValues());
+            writeKDSoapValueListHierarchy(namespacePrefixes, writer, addressingNS, value.childValues());
         }
 
         writer.writeEndElement();
@@ -269,7 +296,7 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
     Q_UNUSED(messageNamespace);
     Q_UNUSED(forceQualified);
 
-    if (d->destination == predefinedAddressToString(None)) {
+    if (d->destination == predefinedAddressToString(None, d->addressingNamespace)) {
         return;
     }
 
@@ -277,8 +304,8 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
         return;
     }
 
-    const QString addressingNS = KDSoapNamespaceManager::soapMessageAddressing();
-
+    const QString addressingNS = addressingNamespaceToString(d->addressingNamespace);
+    
     if (!d->destination.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("To"));
         writer.writeCharacters(d->destination);
@@ -287,19 +314,19 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
 
     if (!d->sourceEndpoint.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("From"));
-        writeAddressField(writer, d->sourceEndpoint.address());
+        writeAddressField(writer, addressingNS, d->sourceEndpoint.address());
         writer.writeEndElement();
     }
 
     if (!d->replyEndpoint.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("ReplyTo"));
-        writeAddressField(writer, d->replyEndpoint.address());
+        writeAddressField(writer, addressingNS, d->replyEndpoint.address());
         writer.writeEndElement();
     }
 
     if (!d->faultEndpoint.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("FaultTo"));
-        writeAddressField(writer, d->faultEndpoint.address());
+        writeAddressField(writer, addressingNS, d->faultEndpoint.address());
         writer.writeEndElement();
     }
 
@@ -332,19 +359,21 @@ void KDSoapMessageAddressingProperties::writeMessageAddressingProperties(KDSoapN
 
     if (!d->referenceParameters.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("ReferenceParameters"));
-        writeKDSoapValueListHierarchy(namespacePrefixes, writer, d->referenceParameters);
+        writeKDSoapValueListHierarchy(namespacePrefixes, writer, addressingNS, d->referenceParameters);
         writer.writeEndElement();
     }
 
     if (!d->metadata.isEmpty()) {
         writer.writeStartElement(addressingNS, QLatin1String("Metadata"));
-        writeKDSoapValueListHierarchy(namespacePrefixes, writer, d->metadata);
+        writeKDSoapValueListHierarchy(namespacePrefixes, writer, addressingNS, d->metadata);
         writer.writeEndElement();
     }
 }
 
 void KDSoapMessageAddressingProperties::readMessageAddressingProperty(const KDSoapValue &value)
 {
+    const QString addressingNS = addressingNamespaceToString(d->addressingNamespace);
+    
     if (value.name() == QLatin1String("Action")) {
         d->action = value.value().toString();
     } else if (value.name() == QLatin1String("MessageID")) {
@@ -358,7 +387,7 @@ void KDSoapMessageAddressingProperties::readMessageAddressingProperty(const KDSo
     } else if (value.name() == QLatin1String("RelatesTo")) {
         KDSoapMessageRelationship::Relationship relationship;
         relationship.uri = (value.value().toString());
-        relationship.relationshipType = QLatin1String("http://www.w3.org/2005/08/addressing/reply");
+        relationship.relationshipType = addressingNS + QLatin1String("/reply");
         foreach (KDSoapValue attr, value.childValues().attributes()) {
             if (attr.name() == QLatin1String("RelationshipType")) {
                 relationship.relationshipType = attr.value().toString();

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.h
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.h
@@ -56,7 +56,8 @@ struct Relationship {
      * Relationship constructor
      * @param URI is supposed to represent a message ID of a previous message you want to make reference to
      * @param type represents the nature of the relation between messages, if none is provided, the following
-     * predefined address will be used http://www.w3.org/2005/08/addressing/reply
+     * predefined address will be used wsa:Reply (which is dependent on the selected namespace, for example 
+     * http://www.w3.org/2005/08/addressing/reply)
      */
     Relationship(const QString &URI, const QString &type = QString())
         : uri(URI), relationshipType(type) {}
@@ -95,6 +96,19 @@ public:
         Anonymous,
         Reply,
         Unspecified
+    };
+    
+    /**
+     * This enum contains all the namespaces that can be used to send out WS-Addressing messages. 
+     * This allows the application to select the WS-Addressing revision to be used.
+     * \since 1.9
+     * \see setAddressingNamespace
+     */
+    enum KDSoapAddressingNamespace {
+        Addressing200303,
+        Addressing200403,
+        Addressing200408,
+        Addressing200508
     };
 
     /**
@@ -265,16 +279,36 @@ public:
      * Add one metadata, if not null, to the list of metadata that will appear within soap header
      */
     void addMetadata(const KDSoapValue &metadata);
+    
+    /**
+     * Returns the selected WS-Addressing namespace
+     * \since 1.9
+     */
+    KDSoapAddressingNamespace addressingNamespace() const;
 
     /**
-     * Helper function that takes the \p address enum to provide the QString equivalent
+     * Sets the WS-Addressing namespace to be used for sending out messages.This allows the 
+     * application to select the WS-Addressing revision to be used.
+     * \since 1.9
+     * \see KDSoapAddressingNamespace
      */
-    static QString predefinedAddressToString(KDSoapAddressingPredefinedAddress address);
+    void setAddressingNamespace(KDSoapAddressingNamespace addressingNamespace);
+  
+    /**
+     * Helper function that takes the \p address enum and \p addressingNamespace to provide the QString equivalent
+     */
+    static QString predefinedAddressToString(KDSoapAddressingPredefinedAddress address, KDSoapAddressingNamespace addressingNamespace = Addressing200508);
 
     /**
      * Helper function that compares \p namespaceUri with the known WS-Addressing namespaces
      */
     static bool isWSAddressingNamespace(const QString& namespaceUri);
+    
+    /**
+     * Helper function that takes the \p addressingNamespace enum to provide the QString equivalent
+     * \since 1.9
+     */
+    static QString addressingNamespaceToString(KDSoapAddressingNamespace addressingNamespace);
 
 private:
     /**

--- a/src/KDSoapClient/KDSoapMessageWriter.cpp
+++ b/src/KDSoapClient/KDSoapMessageWriter.cpp
@@ -52,7 +52,7 @@ QByteArray KDSoapMessageWriter::messageToXml(const KDSoapMessage &message, const
     writer.writeStartDocument();
 
     KDSoapNamespacePrefixes namespacePrefixes;
-    namespacePrefixes.writeStandardNamespaces(writer, m_version, message.hasMessageAddressingProperties());
+    namespacePrefixes.writeStandardNamespaces(writer, m_version, message.hasMessageAddressingProperties(), message.messageAddressingProperties().addressingNamespace());
 
     QString soapEnvelope;
     QString soapEncoding;

--- a/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
@@ -26,7 +26,8 @@
 
 void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter &writer,
         KDSoap::SoapVersion version,
-        bool messageAddressingEnabled)
+        bool messageAddressingEnabled, 
+        KDSoapMessageAddressingProperties::KDSoapAddressingNamespace messageAddressingNamespace)
 {
     if (version == KDSoap::SOAP1_1) {
         writeNamespace(writer, KDSoapNamespaceManager::soapEnvelope(), QLatin1String("soap"));
@@ -40,7 +41,8 @@ void KDSoapNamespacePrefixes::writeStandardNamespaces(QXmlStreamWriter &writer,
     writeNamespace(writer, KDSoapNamespaceManager::xmlSchemaInstance2001(), QLatin1String("xsi"));
 
     if (messageAddressingEnabled) {
-        writeNamespace(writer, KDSoapNamespaceManager::soapMessageAddressing(), QLatin1String("wsa"));
+        const QString addressingNS = KDSoapMessageAddressingProperties::addressingNamespaceToString(messageAddressingNamespace);
+        writeNamespace(writer, addressingNS, QLatin1String("wsa"));
     }
 
     // Also insert known variants

--- a/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
@@ -27,13 +27,16 @@
 #include <QtCore/QXmlStreamWriter>
 
 #include "KDSoapClientInterface.h"
+#include "KDSoapMessageAddressingProperties.h"
 
 class KDSoapNamespacePrefixes : public QMap<QString /*ns*/, QString /*prefix*/>
 {
 public:
     void writeStandardNamespaces(QXmlStreamWriter &writer,
                                  KDSoap::SoapVersion version = KDSoap::SOAP1_1,
-                                 bool messageAddressingEnabled = false);
+                                 bool messageAddressingEnabled = false,
+                                 KDSoapMessageAddressingProperties::KDSoapAddressingNamespace messageAddressingNamespace = KDSoapMessageAddressingProperties::Addressing200508
+                                );
 
     void writeNamespace(QXmlStreamWriter &writer, const QString &ns, const QString &prefix)
     {

--- a/unittests/ws_addressing_support/wsaddressingtest.cpp
+++ b/unittests/ws_addressing_support/wsaddressingtest.cpp
@@ -53,6 +53,9 @@ private Q_SLOTS:
 
         QString unspecified = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Unspecified);
         QCOMPARE(unspecified, QString("http://www.w3.org/2005/08/addressing/unspecified"));
+        
+        QString none200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::None, KDSoapMessageAddressingProperties::Addressing200303);
+        QCOMPARE(none200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/none"));
     }
 
     void shouldWriteAProperSoapMessageWithRightsAddressingProperties()
@@ -72,13 +75,33 @@ private Q_SLOTS:
         KDSoapMessage reply = client.call(QLatin1String("sayHello"), message, action);
 
         // THEN
-        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage()));
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage200508()));
+    }
+    
+    void shouldWriteAProperSoapMessageWithAlternativeNamespace()
+    {
+        // GIVEN
+        HttpServerThread server(emptyResponse(), HttpServerThread::Public);
+        KDSoapClientInterface client(server.endPoint(), "http://www.ecerami.com/wsdl/HelloService");
+
+        KDSoapMessage message;
+        const QString action = QString::fromLatin1("sayHello");
+        message.setUse(KDSoapMessage::EncodedUse);
+        message.addArgument(QString::fromLatin1("msg"), QVariant::fromValue(QString("HelloContentMessage")), KDSoapNamespaceManager::xmlSchema2001(), QString::fromLatin1("string"));
+        message.setNamespaceUri(QString::fromLatin1("http://www.ecerami.com/wsdl/HelloService.wsdl"));
+
+        // WHEN
+        message.setMessageAddressingProperties(addressingProperties200408());
+        KDSoapMessage reply = client.call(QLatin1String("sayHello"), message, action);
+
+        // THEN
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedSoapMessage200408()));
     }
 
     void shouldReadAProperSoapMessageWithRightsAddressingProperties()
     {
         // GIVEN
-        HttpServerThread server(expectedSoapMessage(), HttpServerThread::Public);
+        HttpServerThread server(expectedSoapMessage200508(), HttpServerThread::Public);
         KDSoapClientInterface client(server.endPoint(), "http://www.ecerami.com/wsdl/HelloService");
 
         KDSoapMessage message;
@@ -159,11 +182,31 @@ private:
 
         return map;
     }
-
-    static QByteArray expectedSoapMessage()
+    
+    static KDSoapMessageAddressingProperties addressingProperties200408()
     {
-        return QByteArray(xmlEnvBegin11()) + " xmlns:wsa=\"http://www.w3.org/2005/08/addressing\""
-               + " xmlns:n1=\"http://www.ecerami.com/wsdl/HelloService.wsdl\">"
+        KDSoapMessageAddressingProperties map = addressingProperties();
+        map.setAddressingNamespace(KDSoapMessageAddressingProperties::Addressing200408);
+        return map;
+    }
+    
+    static QByteArray expectedSoapMessage200408()
+    {
+        return QByteArray(xmlEnvBegin11()) + 
+               " xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\"" +
+               expectedSoapMessagePartial();
+    }
+        
+    static QByteArray expectedSoapMessage200508()
+    {
+        return QByteArray(xmlEnvBegin11()) + 
+               " xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"" +
+               expectedSoapMessagePartial();
+    }
+
+    static QByteArray expectedSoapMessagePartial()
+    {
+        return QByteArray(" xmlns:n1=\"http://www.ecerami.com/wsdl/HelloService.wsdl\">") +
                "<soap:Header>"
                "<wsa:To>http://www.ecerami.com/wsdl/HelloService</wsa:To>"
                "<wsa:From>"


### PR DESCRIPTION
This adds the option to select the namespace used when sending
WS-Addressing messages. This is needed because the WS-Discovery spec
explicitly mentions the WS-Addressing 2004-08 namespace and some devices
will only respond to messages using that specific namespace.

Tested with [kdsoap-ws-discovery-client](https://gitlab.com/caspermeijn/kdsoap-ws-discovery-client) and [wsdd](https://github.com/KoynovStas/wsdd).