### PR TITLE
Add c++11 override indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,10 @@ if(MSVC)
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 endif()
 
+if (NOT MSVC)
+  add_compile_options(-Wsuggest-override)
+endif()
+
 if(${PROJECT_NAME}_STATIC)
   set(${PROJECT_NAME}_LIBRARY_MODE "STATIC")
 else()

--- a/doc/CHANGES_1_9.txt
+++ b/doc/CHANGES_1_9.txt
@@ -1,0 +1,12 @@
+General:
+========
+
+Client-side:
+============
+
+Server-side:
+============
+
+WSDL parser / code generator changes, applying to both client and server side:
+================================================================
+* Add override indicator to generated files. This requires c++11 for users of generated files.

--- a/examples/helloworld_server/helloworld_server.h
+++ b/examples/helloworld_server/helloworld_server.h
@@ -12,7 +12,7 @@ public:
     ServerObject();
     ~ServerObject();
 
-    QString sayHello(const QString& msg);
+    QString sayHello(const QString& msg) override;
 };
 
 #endif // HELLOWORLD_SERVER_H

--- a/examples/helloworld_server/main.cpp
+++ b/examples/helloworld_server/main.cpp
@@ -24,7 +24,7 @@ QString ServerObject::sayHello(const QString& msg)
 
 class Server : public KDSoapServer {
 public:
-    QObject* createServerObject() {
+    QObject* createServerObject() override {
         return new ServerObject;
     }
 };

--- a/kdwsdl2cpp/libkode/function.h
+++ b/kdwsdl2cpp/libkode/function.h
@@ -137,7 +137,7 @@ class KODE_EXPORT Function
      */
     bool isStatic() const;
 
-    enum VirtualMode { NotVirtual, Virtual, PureVirtual };
+    enum VirtualMode { NotVirtual, Virtual, PureVirtual, Override };
     /**
      * Sets whether the function is marked as virtual or pure virtual.
      */

--- a/kdwsdl2cpp/libkode/printer.cpp
+++ b/kdwsdl2cpp/libkode/printer.cpp
@@ -600,6 +600,10 @@ QString Printer::functionSignature( const Function &function,
 
   if ( function.isConst() )
     s += " const";
+  
+  if ( function.virtualMode() == Function::Override && !forImplementation ) {
+    s += " override";
+  }
 
   if ( function.virtualMode() == Function::PureVirtual )
     s += " = 0";

--- a/kdwsdl2cpp/schema/complextype.h
+++ b/kdwsdl2cpp/schema/complextype.h
@@ -58,7 +58,7 @@ public:
     void setDocumentation(const QString &documentation);
     QString documentation() const;
 
-    bool isSimple() const;
+    bool isSimple() const override;
 
     // True if this is the base class for other (derived) complex types
     bool isPolymorphicBaseClass() const;

--- a/kdwsdl2cpp/src/converter_clientstub.cpp
+++ b/kdwsdl2cpp/src/converter_clientstub.cpp
@@ -413,6 +413,7 @@ bool Converter::convertClientService()
                 }
 
                 KODE::Function doStart(QLatin1String("doStart"), QLatin1String("void"), KODE::Function::Protected);
+                doStart.setVirtualMode(KODE::Function::Override);
                 KODE::Code doStartCode;
                 const bool hasAction = clientAddAction(doStartCode, binding, operationName);
                 clientGenerateMessage(doStartCode, binding, message, operation, /*use members=*/true);

--- a/kdwsdl2cpp/src/converter_complextype.cpp
+++ b/kdwsdl2cpp/src/converter_complextype.cpp
@@ -264,7 +264,11 @@ void Converter::convertComplexType(const XSD::ComplexType *type)
         KODE::Function clone("_kd_clone");
         clone.setConst(true);
         clone.setReturnType(pbc + QLatin1String(" *"));
-        clone.setVirtualMode(KODE::Function::Virtual);
+        if (newClass.baseClasses().isEmpty()) {
+            clone.setVirtualMode(KODE::Function::Virtual);
+        } else {
+            clone.setVirtualMode(KODE::Function::Override);
+        }
         clone.setBody(QLatin1String("return new ") + newClassName + QLatin1String("(*this);"));
         newClass.addFunction(clone);
 
@@ -273,14 +277,22 @@ void Converter::convertComplexType(const XSD::ComplexType *type)
             KODE::Function substGetter("_kd_substitutionElementName");
             substGetter.setConst(true);
             substGetter.setReturnType(QLatin1String("QString"));
-            substGetter.setVirtualMode(KODE::Function::Virtual);
+            if (newClass.baseClasses().isEmpty()) {
+                substGetter.setVirtualMode(KODE::Function::Virtual);
+            } else {
+                substGetter.setVirtualMode(KODE::Function::Override);
+            }
             substGetter.setBody(QString::fromLatin1("return QString::fromLatin1(\"%1\");").arg(substElementName.localName()));
             newClass.addFunction(substGetter);
 
             KODE::Function substNSGetter("_kd_substitutionElementNameSpace");
             substNSGetter.setConst(true);
             substNSGetter.setReturnType(QLatin1String("QString"));
-            substNSGetter.setVirtualMode(KODE::Function::Virtual);
+            if (newClass.baseClasses().isEmpty()) {
+                substNSGetter.setVirtualMode(KODE::Function::Virtual);
+            } else {
+                substNSGetter.setVirtualMode(KODE::Function::Override);
+            }
             substNSGetter.setBody(QString::fromLatin1("return QString::fromLatin1(\"%1\");").arg(substElementName.nameSpace()));
             newClass.addFunction(substNSGetter);
         }
@@ -556,12 +568,18 @@ void Converter::createComplexTypeSerializer(KODE::Class &newClass, const XSD::Co
     if (!type->derivedTypes().isEmpty()) {
         serializeFunc.setVirtualMode(KODE::Function::Virtual);
     }
+    if (!newClass.baseClasses().isEmpty()) {
+        serializeFunc.setVirtualMode(KODE::Function::Override);
+    }
     serializeFunc.setConst(true);
 
     KODE::Function deserializeFunc(QLatin1String("deserialize"), QLatin1String("void"));
     deserializeFunc.addArgument(QLatin1String("const KDSoapValue& mainValue"));
     if (!type->derivedTypes().isEmpty()) {
         deserializeFunc.setVirtualMode(KODE::Function::Virtual);
+    }
+    if (!newClass.baseClasses().isEmpty()) {
+        deserializeFunc.setVirtualMode(KODE::Function::Override);
     }
 
     KODE::Code marshalCode, demarshalCode;

--- a/kdwsdl2cpp/src/converter_serverstub.cpp
+++ b/kdwsdl2cpp/src/converter_serverstub.cpp
@@ -45,6 +45,7 @@ void Converter::convertServerService()
             processRequestMethod.addArgument("const KDSoapMessage &_request");
             processRequestMethod.addArgument("KDSoapMessage &_response");
             processRequestMethod.addArgument("const QByteArray& _soapAction");
+            processRequestMethod.setVirtualMode(KODE::Function::Override);
 
             KODE::Code body;
             const QString responseNs = mWSDL.definitions().targetNamespace();

--- a/kdwsdl2cpp/wsdl/soapbinding.h
+++ b/kdwsdl2cpp/wsdl/soapbinding.h
@@ -296,19 +296,19 @@ public:
     void setBinding(const Binding &binding);
     Binding binding() const;
 
-    void parseBinding(ParserContext *context, const QDomElement &parent);
-    void parseOperation(ParserContext *context, const QString &name, const QDomElement &parent);
-    void parseOperationInput(ParserContext *context, const QString &name, const QDomElement &parent);
-    void parseOperationOutput(ParserContext *context, const QString &name, const QDomElement &parent);
-    void parseOperationFault(ParserContext *context, const QString &name, const QDomElement &parent);
-    void parsePort(ParserContext *context, const QDomElement &parent);
+    void parseBinding(ParserContext *context, const QDomElement &parent) override;
+    void parseOperation(ParserContext *context, const QString &name, const QDomElement &parent) override;
+    void parseOperationInput(ParserContext *context, const QString &name, const QDomElement &parent) override;
+    void parseOperationOutput(ParserContext *context, const QString &name, const QDomElement &parent) override;
+    void parseOperationFault(ParserContext *context, const QString &name, const QDomElement &parent) override;
+    void parsePort(ParserContext *context, const QDomElement &parent) override;
 
-    void synthesizeBinding(ParserContext *context, QDomDocument &document, QDomElement &parent) const;
-    void synthesizeOperation(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const;
-    void synthesizeOperationInput(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const;
-    void synthesizeOperationOutput(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const;
-    void synthesizeOperationFault(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const;
-    void synthesizePort(ParserContext *context, QDomDocument &document, QDomElement &parent) const;
+    void synthesizeBinding(ParserContext *context, QDomDocument &document, QDomElement &parent) const override;
+    void synthesizeOperation(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const override;
+    void synthesizeOperationInput(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const override;
+    void synthesizeOperationOutput(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const override;
+    void synthesizeOperationFault(ParserContext *context, const QString &name, QDomDocument &document, QDomElement &parent) const override;
+    void synthesizePort(ParserContext *context, QDomDocument &document, QDomElement &parent) const override;
 
 private:
     Binding mBinding;

--- a/src/KDSoapClient/KDSoapClientThread_p.h
+++ b/src/KDSoapClient/KDSoapClientThread_p.h
@@ -100,7 +100,7 @@ public:
     void stop();
 
 protected:
-    virtual void run();
+    virtual void run() override;
 
 private:
     QMutex m_mutex;

--- a/src/KDSoapServer/KDSoapServer.h
+++ b/src/KDSoapServer/KDSoapServer.h
@@ -275,9 +275,9 @@ Q_SIGNALS:
 
 protected:
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
-    /*! \reimp \internal */ void incomingConnection(qintptr socketDescriptor);
+    /*! \reimp \internal */ void incomingConnection(qintptr socketDescriptor) override;
 #else
-    /*! \reimp \internal */ void incomingConnection(int socketDescriptor);
+    /*! \reimp \internal */ void incomingConnection(int socketDescriptor) override;
 #endif
 
 private:

--- a/src/KDSoapServer/KDSoapServerThread_p.h
+++ b/src/KDSoapServer/KDSoapServerThread_p.h
@@ -77,7 +77,7 @@ public:
     void handleIncomingConnection(int socketDescriptor, KDSoapServer *server);
 
 protected:
-    virtual void run();
+    virtual void run() override;
 
 private:
     void start(); // use startThread instead

--- a/testtools/httpserver_p.cpp
+++ b/testtools/httpserver_p.cpp
@@ -225,9 +225,9 @@ public:
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
-    virtual void incomingConnection(qintptr socketDescriptor)
+    virtual void incomingConnection(qintptr socketDescriptor) override
 #else
-    virtual void incomingConnection(int socketDescriptor)
+    virtual void incomingConnection(int socketDescriptor) override
 #endif
     {
 #ifndef QT_NO_OPENSSL

--- a/testtools/httpserver_p.h
+++ b/testtools/httpserver_p.h
@@ -119,7 +119,7 @@ public:
     }
 
 protected:
-    /* \reimp */ void run();
+    /* \reimp */ void run() override;
 
 private:
 

--- a/unittests/ihc_wsdl/test_ihc.cpp
+++ b/unittests/ihc_wsdl/test_ihc.cpp
@@ -38,19 +38,19 @@ class IHCServerObject : public ResourceInteractionServiceServiceServerBase
 {
 public:
 
-    virtual TNS__WSResourceValueEnvelope getRuntimeValue(int)
+    virtual TNS__WSResourceValueEnvelope getRuntimeValue(int) override
     {
         return TNS__WSResourceValueEnvelope();
     }
-    virtual TNS__ArrayOfWSResourceValueEnvelope getRuntimeValues(const XSD__ArrayOfint &)
+    virtual TNS__ArrayOfWSResourceValueEnvelope getRuntimeValues(const XSD__ArrayOfint &) override
     {
         return TNS__ArrayOfWSResourceValueEnvelope();
     }
-    virtual TNS__ArrayOfWSResourceValueEnvelope getInitialValues(const XSD__ArrayOfint &)
+    virtual TNS__ArrayOfWSResourceValueEnvelope getInitialValues(const XSD__ArrayOfint &) override
     {
         return TNS__ArrayOfWSResourceValueEnvelope();
     }
-    virtual bool setResourceValue(const TNS__WSResourceValueEnvelope &parameter4)
+    virtual bool setResourceValue(const TNS__WSResourceValueEnvelope &parameter4) override
     {
         Q_ASSERT(parameter4.typeString() == "enum");
 #ifdef __clang__
@@ -86,63 +86,63 @@ public:
         return (parameter4.typeString() == "enum" && inputValue->enumValueID() == 42);
         */
     }
-    virtual bool setResourceValues(const TNS__ArrayOfWSResourceValueEnvelope &)
+    virtual bool setResourceValues(const TNS__ArrayOfWSResourceValueEnvelope &) override
     {
         return false;
     }
-    virtual TNS__ArrayOfWSResourceValueEnvelope enableRuntimeValueNotifications(const XSD__ArrayOfint &)
+    virtual TNS__ArrayOfWSResourceValueEnvelope enableRuntimeValueNotifications(const XSD__ArrayOfint &) override
     {
         return TNS__ArrayOfWSResourceValueEnvelope();
     }
-    virtual bool disableRuntimeValueNotifactions(const XSD__ArrayOfint &)
+    virtual bool disableRuntimeValueNotifactions(const XSD__ArrayOfint &) override
     {
         return false;
     }
-    virtual TNS__ArrayOfWSResourceValueEnvelope enableInitialValueNotifications(const XSD__ArrayOfint &)
+    virtual TNS__ArrayOfWSResourceValueEnvelope enableInitialValueNotifications(const XSD__ArrayOfint &) override
     {
         return TNS__ArrayOfWSResourceValueEnvelope();
     }
-    virtual bool disableInitialValueNotifactions(const XSD__ArrayOfint &)
+    virtual bool disableInitialValueNotifactions(const XSD__ArrayOfint &) override
     {
         return false;
     }
-    virtual TNS__ArrayOfWSResourceValueEnvelope waitForResourceValueChanges(int)
+    virtual TNS__ArrayOfWSResourceValueEnvelope waitForResourceValueChanges(int) override
     {
         return TNS__ArrayOfWSResourceValueEnvelope();
     }
-    virtual TNS__ArrayOfWSSceneResourceIdAndLocationURLs getSceneGroupResourceIdAndPositions(int)
+    virtual TNS__ArrayOfWSSceneResourceIdAndLocationURLs getSceneGroupResourceIdAndPositions(int) override
     {
         return TNS__ArrayOfWSSceneResourceIdAndLocationURLs();
     }
-    virtual TNS__WSSceneResourceIdAndLocationURLs getScenePositionsForSceneValueResource(int)
+    virtual TNS__WSSceneResourceIdAndLocationURLs getScenePositionsForSceneValueResource(int) override
     {
         return TNS__WSSceneResourceIdAndLocationURLs();
     }
-    virtual WPNS1__ArrayOfWSEnumDefinition getEnumeratorDefinitions()
+    virtual WPNS1__ArrayOfWSEnumDefinition getEnumeratorDefinitions() override
     {
         return WPNS1__ArrayOfWSEnumDefinition();
     }
-    virtual QString getResourceType(int)
+    virtual QString getResourceType(int) override
     {
         return QString();
     }
-    virtual TNS__ArrayOfWSDatalineResource getExtraDatalineInputs()
+    virtual TNS__ArrayOfWSDatalineResource getExtraDatalineInputs() override
     {
         return TNS__ArrayOfWSDatalineResource();
     }
-    virtual TNS__ArrayOfWSDatalineResource getExtraDatalineOutputs()
+    virtual TNS__ArrayOfWSDatalineResource getExtraDatalineOutputs() override
     {
         return TNS__ArrayOfWSDatalineResource();
     }
-    virtual TNS__ArrayOfWSDatalineResource getAllDatalineInputs()
+    virtual TNS__ArrayOfWSDatalineResource getAllDatalineInputs() override
     {
         return TNS__ArrayOfWSDatalineResource();
     }
-    virtual TNS__ArrayOfWSDatalineResource getAllDatalineOutputs()
+    virtual TNS__ArrayOfWSDatalineResource getAllDatalineOutputs() override
     {
         return TNS__ArrayOfWSDatalineResource();
     }
-    virtual TNS__WSResourceValueEnvelope getInitialValue(int)
+    virtual TNS__WSResourceValueEnvelope getInitialValue(int) override
     {
         return TNS__WSResourceValueEnvelope();
     }
@@ -155,7 +155,7 @@ public:
     IHCServer() : KDSoapServer(), m_lastServerObject(0)
     {
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new IHCServerObject;
         return m_lastServerObject;

--- a/unittests/prefix_wsdl/test_prefix.cpp
+++ b/unittests/prefix_wsdl/test_prefix.cpp
@@ -39,12 +39,12 @@ class GuestServerObject : public GuestServerBase /* generated from wsdl */
 {
     Q_OBJECT
 public:
-    virtual TNS__AddPersonResponse addPerson(const TNS__AddPersonRequest &parameters)
+    virtual TNS__AddPersonResponse addPerson(const TNS__AddPersonRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__AddPersonResponse();
     }
-    virtual TNS__AuthenticateResponse authenticate(const TNS__AuthenticateRequest &parameters)
+    virtual TNS__AuthenticateResponse authenticate(const TNS__AuthenticateRequest &parameters) override
     {
         if (parameters.serijskiBrojSertifikata() == "cert") {
             TNS__AuthenticateResponse response;
@@ -56,52 +56,52 @@ public:
         }
         return TNS__AuthenticateResponse();
     }
-    virtual TNS__SearchPersonResponse searchPerson(const TNS__SearchPersonRequest &parameters)
+    virtual TNS__SearchPersonResponse searchPerson(const TNS__SearchPersonRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__SearchPersonResponse();
     }
-    virtual TNS__EditPersonResponse editPerson(const TNS__EditPersonRequest &parameters)
+    virtual TNS__EditPersonResponse editPerson(const TNS__EditPersonRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__EditPersonResponse();
     }
-    virtual TNS__CityListResponse cityList(const TNS__CityListRequest &parameters)
+    virtual TNS__CityListResponse cityList(const TNS__CityListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__CityListResponse();
     }
-    virtual TNS__PlaceListResponse placeList(const TNS__PlaceListRequest &parameters)
+    virtual TNS__PlaceListResponse placeList(const TNS__PlaceListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__PlaceListResponse();
     }
-    virtual TNS__DocumentListResponse documentList(const TNS__DocumentListRequest &parameters)
+    virtual TNS__DocumentListResponse documentList(const TNS__DocumentListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__DocumentListResponse();
     }
-    virtual TNS__GuestTypeListResponse guestTypeList(const TNS__GuestTypeListRequest &parameters)
+    virtual TNS__GuestTypeListResponse guestTypeList(const TNS__GuestTypeListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__GuestTypeListResponse();
     }
-    virtual TNS__CountrytListResponse countrytList(const TNS__CountrytListRequest &parameters)
+    virtual TNS__CountrytListResponse countrytList(const TNS__CountrytListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__CountrytListResponse();
     }
-    virtual TNS__BuildingListResponse buildingList(const TNS__BuildingListRequest &parameters)
+    virtual TNS__BuildingListResponse buildingList(const TNS__BuildingListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__BuildingListResponse();
     }
-    virtual TNS__EntranceListResponse entranceList(const TNS__EntranceListRequest &parameters)
+    virtual TNS__EntranceListResponse entranceList(const TNS__EntranceListRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__EntranceListResponse();
     }
-    virtual TNS__ServiceResponse service(const TNS__ServiceRequest &parameters)
+    virtual TNS__ServiceResponse service(const TNS__ServiceRequest &parameters) override
     {
         Q_UNUSED(parameters);
         return TNS__ServiceResponse();
@@ -116,7 +116,7 @@ public:
     {
         setPath(QLatin1String("/xml"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new GuestServerObject;
         return m_lastServerObject;

--- a/unittests/servertest/servertest.cpp
+++ b/unittests/servertest/servertest.cpp
@@ -98,9 +98,9 @@ public:
         s_serverObjects.remove(QThread::currentThread());
     }
 
-    virtual void processRequest(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction);
+    virtual void processRequest(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction) override;
 
-    virtual QIODevice *processFileRequest(const QString &path, QByteArray &contentType)
+    virtual QIODevice *processFileRequest(const QString &path, QByteArray &contentType) override
     {
         if (path == QLatin1String("/path/to/file_download.txt")) {
             QFile *file = new QFile(QLatin1String("file_download.txt")); // local file, created by the unittest
@@ -110,7 +110,7 @@ public:
         return 0;
     }
 
-    virtual bool validateAuthentication(const KDSoapAuthentication &auth, const QString &path)
+    virtual bool validateAuthentication(const KDSoapAuthentication &auth, const QString &path) override
     {
         if (!m_requireAuth) {
             return true;
@@ -123,7 +123,7 @@ public:
     }
 
     // KDSoapServerRawXMLInterface interface
-    bool newRequest(const QByteArray &requestType, const QMap<QByteArray, QByteArray> &httpHeaders)
+    bool newRequest(const QByteArray &requestType, const QMap<QByteArray, QByteArray> &httpHeaders) override
     {
         if (m_useRawXML && requestType == "POST") {
             if (!httpHeaders.contains("content-type")
@@ -137,7 +137,7 @@ public:
         }
         return false;
     }
-    void processXML(const QByteArray &xmlChunk)
+    void processXML(const QByteArray &xmlChunk) override
     {
         if (!m_useRawXML) { // should never happen
             Q_ASSERT(m_useRawXML);
@@ -145,7 +145,7 @@ public:
         }
         m_assembledXML += xmlChunk;
     }
-    void endRequest()
+    void endRequest() override
     {
         if (m_assembledXML != rawCountryMessage(s_longEmployeeName)) {
             qWarning() << "Expected" << rawCountryMessage(s_longEmployeeName) << "\nGot" << m_assembledXML;
@@ -161,7 +161,7 @@ public:
 
     // KDSoapServerCustomVerbRequestInterface
     virtual bool processCustomVerbRequest(const QByteArray &requestType, const QByteArray &requestData,
-                                          const QMap<QByteArray, QByteArray> &httpHeaders, QByteArray &customAnswer)
+                                          const QMap<QByteArray, QByteArray> &httpHeaders, QByteArray &customAnswer) override
     {
         Q_UNUSED(requestData);
         Q_UNUSED(httpHeaders);
@@ -177,7 +177,7 @@ public:
         return false;
     }
 
-    virtual HttpResponseHeaderItems additionalHttpResponseHeaderItems() const
+    virtual HttpResponseHeaderItems additionalHttpResponseHeaderItems() const override
     {
         static KDSoapServerObjectInterface::HttpResponseHeaderItems result = KDSoapServerObjectInterface::HttpResponseHeaderItems()
                 <<  KDSoapServerObjectInterface::HttpResponseHeaderItem("Access-Control-Allow-Origin", "*")
@@ -246,7 +246,7 @@ class CountryServer : public KDSoapServer
 public:
     CountryServer() : KDSoapServer(), m_requireAuth(false), m_useRawXML(false) {}
 
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         return new CountryServerObject(m_requireAuth, m_useRawXML);
     }
@@ -321,7 +321,7 @@ public:
     }
 
 protected:
-    void run()
+    void run() override
     {
         CountryServer server;
         if (m_threadPool) {

--- a/unittests/tech3356_wsdl/test_tech3356.cpp
+++ b/unittests/tech3356_wsdl/test_tech3356.cpp
@@ -39,7 +39,7 @@ class TransformMediaBindingServerObject : public TransformMediaBindingServerBase
 {
     Q_OBJECT
 public:
-    virtual TFMS__TransformResponseType transform(const TFMS__TransformRequestType &in)
+    virtual TFMS__TransformResponseType transform(const TFMS__TransformRequestType &in) override
     {
         TFMS__TransformJobType copyJob = in.transformJob();
         Q_ASSERT(copyJob.operationName() == "operation");
@@ -61,7 +61,7 @@ public:
     {
         setPath(QLatin1String("/xml"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new TransformMediaBindingServerObject;
         return m_lastServerObject;
@@ -81,7 +81,7 @@ class TransformMediaStatusBindingServerObject : public TransformMediaStatusBindi
 {
     Q_OBJECT
 public:
-    virtual BMS__ManageJobResponseType manageJob(const BMS__ManageJobRequestType &in)
+    virtual BMS__ManageJobResponseType manageJob(const BMS__ManageJobRequestType &in) override
     {
         // check what was sent
         Q_UNUSED(in);
@@ -98,13 +98,13 @@ public:
         Q_ASSERT(response.job().status().type() == BMS__JobStatusType::Running);
         return response;
     }
-    virtual BMS__ManageQueueResponseType manageQueue(const BMS__ManageQueueRequestType &in)
+    virtual BMS__ManageQueueResponseType manageQueue(const BMS__ManageQueueRequestType &in) override
     {
         Q_UNUSED(in);
         BMS__ManageQueueResponseType qrt;
         return qrt;
     }
-    virtual BMS__QueryJobResponseType queryJob(const BMS__QueryJobRequestType &in)
+    virtual BMS__QueryJobResponseType queryJob(const BMS__QueryJobRequestType &in) override
     {
         Q_UNUSED(in);
         BMS__QueryJobResponseType jrt;
@@ -120,7 +120,7 @@ public:
     {
         setPath(QLatin1String("/xml"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new TransformMediaStatusBindingServerObject;
         return m_lastServerObject;

--- a/unittests/wsdl_document/test_wsdl_document.cpp
+++ b/unittests/wsdl_document/test_wsdl_document.cpp
@@ -761,13 +761,13 @@ class NameServiceServerObject : public NamesServiceServiceServerBase /* generate
 {
     Q_OBJECT
 public:
-    virtual TNS__GetCountriesResponse getCountries(const TNS__GetCountries &)
+    virtual TNS__GetCountriesResponse getCountries(const TNS__GetCountries &) override
     {
         TNS__GetCountriesResponse response;
         response.setCountry(QStringList() << QLatin1String("Great Britain") << QLatin1String("Ireland"));
         return response;
     }
-    TNS__GetNamesInCountryResponse getNamesInCountry(const TNS__GetNamesInCountry &parameters)
+    TNS__GetNamesInCountryResponse getNamesInCountry(const TNS__GetNamesInCountry &parameters) override
     {
         TNS__GetNamesInCountryResponse response;
         if (parameters.country() == QLatin1String("Ireland")) {
@@ -777,7 +777,7 @@ public:
     }
 
     void getNameInfoResponse(const KDSoapDelayedResponseHandle &responseHandle, const TNS__GetNameInfoResponse &ret);
-    virtual TNS__GetNameInfoResponse getNameInfo(const TNS__GetNameInfo &parameters)
+    virtual TNS__GetNameInfoResponse getNameInfo(const TNS__GetNameInfo &parameters) override
     {
         setFault(QLatin1String("Server.Implementation"), QLatin1String("Not implemented"), QLatin1String(metaObject()->className()), parameters.name());
         return TNS__GetNameInfoResponse();
@@ -788,7 +788,7 @@ class DocServerObject : public MyWsdlDocumentServerBase /* generated from mywsdl
 {
     Q_OBJECT
 public:
-    QByteArray addEmployee(const KDAB__AddEmployee &parameters)
+    QByteArray addEmployee(const KDAB__AddEmployee &parameters) override
     {
         //qDebug() << "addEmployee called";
         const QString name = KDAB__LimitedString(parameters.employeeName()).value();
@@ -810,7 +810,7 @@ public:
         return "added " + name.toLatin1();
     }
 
-    QByteArray delayedAddEmployee(const KDAB__AddEmployee &parameters)
+    QByteArray delayedAddEmployee(const KDAB__AddEmployee &parameters) override
     {
         //qDebug() << "delayedAddEmployee called";
         Q_UNUSED(parameters);
@@ -822,23 +822,23 @@ public:
         return "THIS VALUE IS IGNORED";
     }
 
-    void listEmployees()
+    void listEmployees() override
     {
         m_lastMethodCalled = QLatin1String("listEmployees");
     }
-    void heart_beat()
+    void heart_beat() override
     {
         m_lastMethodCalled = QLatin1String("heartbeat");
     }
 
-    KDAB__AnyTypeResponse testAnyType(const KDAB__AnyType &parameters)
+    KDAB__AnyTypeResponse testAnyType(const KDAB__AnyType &parameters) override
     {
         KDAB__AnyTypeResponse response;
         response.setReturn(QList<KDSoapValue>() << parameters.input());
         return response;
     }
 
-    KDAB__EmployeeCountryResponse getEmployeeCountry(const KDAB__EmployeeNameParams &employeeNameParams)
+    KDAB__EmployeeCountryResponse getEmployeeCountry(const KDAB__EmployeeNameParams &employeeNameParams) override
     {
         KDAB__EmployeeCountryResponse resp;
         if (QString(employeeNameParams.employeeName().value()) == QLatin1String("David")) {
@@ -849,7 +849,7 @@ public:
         return resp;
     }
 
-    KDAB__EmployeeType getEmployeeType(const KDAB__EmployeeNameParams &employeeNameParams)
+    KDAB__EmployeeType getEmployeeType(const KDAB__EmployeeNameParams &employeeNameParams) override
     {
         KDAB__EmployeeType type;
         type.setWeakType(QVariant(42)); // anySimpleType was mapped to QVariant
@@ -859,12 +859,12 @@ public:
         return type;
     }
 
-    KDAB__TelegramType sendRawTelegram(const KDAB__TelegramType &telegram)
+    KDAB__TelegramType sendRawTelegram(const KDAB__TelegramType &telegram) override
     {
         return QByteArray("Got ") + telegram;
     }
 
-    KDAB__TelegramResponse sendTelegram(const KDAB__TelegramRequest &parameters)
+    KDAB__TelegramResponse sendTelegram(const KDAB__TelegramRequest &parameters) override
     {
         KDAB__TelegramResponse resp;
         resp.setTelegramHex(QByteArray("Received ") + parameters.telegramHex());
@@ -873,7 +873,7 @@ public:
     }
 
     // Normally you don't reimplement this. This is just to store req and resp for the unittest.
-    void processRequest(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction)
+    void processRequest(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction) override
     {
         m_request = request;
         MyWsdlDocumentServerBase::processRequest(request, response, soapAction);
@@ -881,7 +881,7 @@ public:
         //qDebug() << "processRequest: done. " << this << "Response name=" << response.name();
     }
 
-    void processRequestWithPath(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction, const QString &path)
+    void processRequestWithPath(const KDSoapMessage &request, KDSoapMessage &response, const QByteArray &soapAction, const QString &path) override
     {
         Q_UNUSED(request);
         Q_UNUSED(response);
@@ -919,7 +919,7 @@ public:
     {
         setPath(QLatin1String("/xml"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new DocServerObject;
         return m_lastServerObject;

--- a/unittests/wsdl_rpc-server/test_wsdl_rpc_server.cpp
+++ b/unittests/wsdl_rpc-server/test_wsdl_rpc_server.cpp
@@ -44,7 +44,7 @@ using namespace KDSoapUnitTestHelpers;
 class HelloServerObject : public Hello_ServiceServerBase
 {
 public:
-    virtual QString sayHello(const QString &firstName, const QString &lastName)
+    virtual QString sayHello(const QString &firstName, const QString &lastName) override
     {
         m_receivedFirstName = firstName;
         m_receivedLastName = lastName;
@@ -71,7 +71,7 @@ public:
     {
         setPath(QLatin1String("/hello"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new HelloServerObject;
         return m_lastServerObject;
@@ -90,7 +90,7 @@ public:
     RpcExampleServerObject()
         : m_heartbeatCalled(false)
     {}
-    virtual RPCEXAMPLE__ListKeysResult listKeys(const RPCEXAMPLE__ListKeysParams &params)
+    virtual RPCEXAMPLE__ListKeysResult listKeys(const RPCEXAMPLE__ListKeysParams &params) override
     {
         Q_UNUSED(params)
         RPCEXAMPLE__ListKeysResult result;
@@ -98,71 +98,71 @@ public:
         return result;
     }
 
-    virtual bool pullFile(const RPCEXAMPLE__PullFileParams &params)
+    virtual bool pullFile(const RPCEXAMPLE__PullFileParams &params) override
     {
         Q_UNUSED(params)
         return false;
     }
 
-    virtual bool putFile(const RPCEXAMPLE__PutFileParams &params)
+    virtual bool putFile(const RPCEXAMPLE__PutFileParams &params) override
     {
         Q_UNUSED(params)
         return false;
     }
 
-    virtual QString getFile(const RPCEXAMPLE__GetFileParams &params)
+    virtual QString getFile(const RPCEXAMPLE__GetFileParams &params) override
     {
         Q_UNUSED(params)
         return QString();
     }
 
-    virtual RPCEXAMPLE__ExecFileResult execFile(const RPCEXAMPLE__ExecFileParams &params)
+    virtual RPCEXAMPLE__ExecFileResult execFile(const RPCEXAMPLE__ExecFileParams &params) override
     {
         Q_UNUSED(params)
         return RPCEXAMPLE__ExecFileResult();
     }
 
-    virtual RPCEXAMPLE__ListFilesResult listFiles()
+    virtual RPCEXAMPLE__ListFilesResult listFiles() override
     {
         return RPCEXAMPLE__ListFilesResult();
     }
 
-    virtual bool setKey(const RPCEXAMPLE__SetKeyParams &params)
+    virtual bool setKey(const RPCEXAMPLE__SetKeyParams &params) override
     {
         Q_UNUSED(params)
         return false;
     }
 
-    virtual QString getKey(const RPCEXAMPLE__GetKeyParams &params)
+    virtual QString getKey(const RPCEXAMPLE__GetKeyParams &params) override
     {
         Q_UNUSED(params)
         return QString();
     }
 
-    virtual bool clearKey(const RPCEXAMPLE__ClearKeyParams &params)
+    virtual bool clearKey(const RPCEXAMPLE__ClearKeyParams &params) override
     {
         Q_UNUSED(params)
         return false;
     }
 
-    virtual QString execAction(const RPCEXAMPLE__ExecActionParams &params)
+    virtual QString execAction(const RPCEXAMPLE__ExecActionParams &params) override
     {
         Q_UNUSED(params)
         return QString();
     }
 
-    virtual void heartbeat(const RPCEXAMPLE__HeartbeatParams &params)
+    virtual void heartbeat(const RPCEXAMPLE__HeartbeatParams &params) override
     {
         Q_UNUSED(params);
         m_heartbeatCalled = true;
     }
 
-    virtual void legacyHeartbeat(const RPCEXAMPLE__LegacyHeartbeatParams &params)
+    virtual void legacyHeartbeat(const RPCEXAMPLE__LegacyHeartbeatParams &params) override
     {
         Q_UNUSED(params)
     }
 
-    virtual void message(const RPCEXAMPLE__MessageParams &params)
+    virtual void message(const RPCEXAMPLE__MessageParams &params) override
     {
         Q_UNUSED(params)
     }
@@ -182,7 +182,7 @@ public:
     {
         setPath(QLatin1String("/rpcexample"));
     }
-    virtual QObject *createServerObject()
+    virtual QObject *createServerObject() override
     {
         m_lastServerObject = new RpcExampleServerObject;
         return m_lastServerObject;


### PR DESCRIPTION
This adds the c++11 override indicator (1) to the library code, (2) to the generated code and (3) enables warnings for missing indicators.
The library is already dependent on c++11, so commit 1 is not a problem. However I am not sure whether the generated code is already dependant on c++11 and whether this would be a problem (commit 2). The third commit enables a warning in CMake, I am not sure whether this is the correct way to do that.
I want this change as recent compilers will show a lot of warning for the generated code of the ONVIF wsdl. 