### PR TITLE
KDSoapUdpClient

### DIFF
--- a/doc/CHANGES_1_9.txt
+++ b/doc/CHANGES_1_9.txt
@@ -4,6 +4,7 @@ General:
 Client-side:
 ============
 * Add support for selecting WS-Addressing namespace for send messages
+* Add support for implementing SOAP-over-UDP clients (see KDSoapUdpClient)
 
 Server-side:
 ============

--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
   KDSoapMessageAddressingProperties.cpp
   KDSoapEndpointReference.cpp
   KDQName.cpp
+  KDSoapUdpClient.cpp
 )
 
 add_library(kdsoap ${KDSoap_LIBRARY_MODE} ${SOURCES})
@@ -69,6 +70,7 @@ if(KDSoap_IS_ROOT_PROJECT)
       KDSoapPendingCall
       KDSoapAuthentication
       KDQName
+      KDSoapUdpClient
     COMMON_HEADER
       KDSoapClient
   )
@@ -91,6 +93,7 @@ if(KDSoap_IS_ROOT_PROJECT)
     KDSoapMessageAddressingProperties.h
     KDSoapEndpointReference.h
     KDQName.h
+    KDSoapUdpClient.h
     DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient
   )
 

--- a/src/KDSoapClient/KDSoapMessage.h
+++ b/src/KDSoapClient/KDSoapMessage.h
@@ -212,5 +212,6 @@ public:
 KDSOAP_EXPORT QDebug operator<<(QDebug dbg, const KDSoapMessage &msg);
 
 Q_DECLARE_METATYPE(KDSoapMessage)
+Q_DECLARE_METATYPE(KDSoapHeaders)
 
 #endif // KDSOAPMESSAGE_H

--- a/src/KDSoapClient/KDSoapUdpClient.cpp
+++ b/src/KDSoapClient/KDSoapUdpClient.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2019  Casper Meijn <casper@meijn.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "KDSoapUdpClient.h"
+#include "KDSoapUdpClient_p.h"
+
+#include "KDSoapMessage.h"
+#include "KDSoapMessageReader_p.h"
+#include "KDSoapMessageWriter_p.h"
+#include <QNetworkInterface>
+
+static const QHostAddress AnyIPv4(QLatin1String("0.0.0.0"));
+
+static bool isMulticastAddress(const QHostAddress &address) {
+    if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+        return address.isInSubnet(QHostAddress (QLatin1String("224.0.0.0")), 4);
+    } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+        return address.isInSubnet(QHostAddress (QLatin1String("ff00::")), 8);
+    }
+    return false;
+}
+
+KDSoapUdpClient::KDSoapUdpClient(QObject *parent) : 
+    QObject(parent),
+    d_ptr(new KDSoapUdpClientPrivate(this))
+{
+    Q_D(KDSoapUdpClient);
+    d->socketIPv4 = new QUdpSocket(this);
+    connect(d->socketIPv4, SIGNAL(readyRead()), d, SLOT(readyRead()));
+    d->socketIPv6 = new QUdpSocket(this);
+    connect(d->socketIPv6, SIGNAL(readyRead()), d, SLOT(readyRead()));
+}
+
+KDSoapUdpClient::~KDSoapUdpClient()
+{
+    delete d_ptr;
+}
+
+bool KDSoapUdpClient::bind(quint16 port, QAbstractSocket::BindMode mode) {
+    Q_D(KDSoapUdpClient);
+    bool rc = true;
+    // Workaround for lack of dual stack sockets in Qt4
+    // Qt5 supports binding to QHostAddress::Any, which will listen on both IPv4 and IPv6 interfaces.
+    rc = d->socketIPv4->bind(AnyIPv4, port, mode) && rc;
+    rc = d->socketIPv6->bind(QHostAddress::AnyIPv6, port, mode) && rc;
+    return rc;
+}
+
+void KDSoapUdpClient::setSoapVersion(KDSoap::SoapVersion version) {
+    Q_D(KDSoapUdpClient);
+    d->soapVersion = version;
+}
+
+bool KDSoapUdpClient::sendMessage(const KDSoapMessage &message, const KDSoapHeaders &headers, const QHostAddress &address, quint16 port) {
+    Q_D(KDSoapUdpClient);
+    KDSoapMessageWriter msgWriter;
+    msgWriter.setVersion(d->soapVersion);
+    const QByteArray data = msgWriter.messageToXml(message, QString(), headers, QMap<QString, KDSoapMessage>());
+    
+    if (isMulticastAddress(address)) {
+        bool anySuccess = false;
+        const auto& allInterfaces = QNetworkInterface::allInterfaces();
+        for (const auto &iface : allInterfaces) {
+            if (iface.flags().testFlag(QNetworkInterface::IsUp) &&
+                iface.flags().testFlag(QNetworkInterface::CanMulticast)) {
+                //qDebug() << "Sending multicast to" << iface.name() << address << ":" << data;
+                if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                    d->socketIPv4->setMulticastInterface(iface);
+                    qint64 writtenSize = d->socketIPv4->writeDatagram(data, address, port);
+                    anySuccess = anySuccess || (writtenSize == data.size());
+                } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+                    d->socketIPv6->setMulticastInterface(iface);
+                    qint64 writtenSize = d->socketIPv6->writeDatagram(data, address, port);
+                    anySuccess = anySuccess || (writtenSize == data.size());
+                }
+            }
+        }
+        return anySuccess;
+    } else {
+        //qDebug() << "Sending to" << address << ":" << data;
+        if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+            qint64 writtenSize = d->socketIPv4->writeDatagram(data, address, port);
+            return writtenSize == data.size();
+        } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+            qint64 writtenSize = d->socketIPv6->writeDatagram(data, address, port);
+            return writtenSize == data.size();
+        }
+    }
+    return false;
+}
+
+void KDSoapUdpClientPrivate::readyRead()
+{
+    QUdpSocket *socket = qobject_cast<QUdpSocket *>(sender());
+    while (socket->hasPendingDatagrams()) {
+        qint64 size = socket->pendingDatagramSize();
+        
+        QByteArray buffer;
+        buffer.resize(size);
+        QHostAddress senderAddress;
+        quint16 senderPort;
+        socket->readDatagram(buffer.data(), buffer.size(), &senderAddress, &senderPort);
+        
+        receivedDatagram(buffer, senderAddress, senderPort);
+    }
+}
+
+void KDSoapUdpClientPrivate::receivedDatagram(const QByteArray &messageData, const QHostAddress &senderAddress, quint16 senderPort)
+{
+    Q_Q(KDSoapUdpClient);
+    //qDebug() << "Received datagram from:" << senderAddress << "data:" << QString::fromUtf8(messageData);
+
+    KDSoapMessage replyMessage;
+    KDSoapHeaders replyHeaders;
+
+    KDSoapMessageReader reader;
+    reader.xmlToMessage(messageData, &replyMessage, 0, &replyHeaders, soapVersion);
+
+    emit q->receivedMessage(replyMessage, replyHeaders, senderAddress, senderPort);
+}

--- a/src/KDSoapClient/KDSoapUdpClient.h
+++ b/src/KDSoapClient/KDSoapUdpClient.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2019  Casper Meijn <casper@meijn.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KDSOAPUDPCLIENT_H
+#define KDSOAPUDPCLIENT_H
+
+#include "KDSoapGlobal.h"
+#include "KDSoapClientInterface.h"
+
+#include <QAbstractSocket>
+#include <QObject>
+
+class KDSoapHeaders;
+class KDSoapMessage;
+class KDSoapUdpClientPrivate;
+QT_BEGIN_NAMESPACE
+class QHostAddress;
+QT_END_NAMESPACE
+
+/**
+ * \brief KDSoapUdpClient provides an interface for implementing a [SOAP-over-UDP](https://docs.oasis-open.org/ws-dd/soapoverudp/1.1/os/wsdd-soapoverudp-1.1-spec-os.html) client.
+ * 
+ * One-way SOAP-over-UDP can be send by simply using sendMessage().
+ * 
+ * Request-response SOAP-over-UDP is supported by bind()ing to a sender UDP 
+ * port.  You can send the request using sendMessage() and the response will is
+ * signaled using receivedMessage(). receivedMessage() will signal any response, 
+ * including those of other requests, there is no help with finding the correct 
+ * response. The WS-Addressing properties of the message can be used to filter 
+ * the received responses.
+ * 
+ * \code
+ * auto soapUdpClient = new KDSoapUdpClient(this);
+ * connect(soapUdpClient, &KDSoapUdpClient::receivedMessage, [=](const KDSoapMessage &message, const KDSoapHeaders &headers, const QHostAddress &address, quint16 port) { 
+ *   if(message.messageAddressingProperties().action() == QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ProbeMatches")) {
+ *     TNS__ProbeMatchesType probeMatches;
+ *     probeMatches.deserialize(message);
+ *     qDebug() << "Received probe match from" << address;
+ *   }
+ * });
+ * soapUdpClient->bind(3702);
+ * 
+ * TNS__ProbeType probe;
+ *
+ * KDSoapMessage message;
+ * message = probe.serialize(QStringLiteral("Probe"));
+ * message.setUse(KDSoapMessage::LiteralUse);
+ * message.setNamespaceUri(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"));
+ *
+ * KDSoapMessageAddressingProperties addressing;
+ * addressing.setAction(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe"));
+ * addressing.setMessageID(QStringLiteral("urn:uuid:") + QUuid::createUuid().toString(QUuid::WithoutBraces));
+ * addressing.setDestination(QStringLiteral("urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01"));
+ * addressing.setReplyEndpointAddress(KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous));
+ * message.setMessageAddressingProperties(addressing);
+ *
+ * soapUdpClient->sendMessage(message, KDSoapHeaders(), QHostAddress("239.255.255.250"), 3702);
+ * \endcode
+ * 
+ * \since 1.9
+ */
+class KDSOAP_EXPORT KDSoapUdpClient : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit KDSoapUdpClient(QObject *parent=nullptr);
+    
+    ~KDSoapUdpClient();
+
+    /**
+     * Bind UDP socket to port. This is needed to recieve messages. Both the 
+     * IPv4 and IPv6 port will be bound.
+     * \param port The UDP port to bind to. When port is 0, a random port is chosen.
+     * \param mode This is passed directly to QUdpSocket::bind().
+     * \see receivedMessage()
+     * \since 1.9
+     */
+    bool bind(quint16 port = 0, QAbstractSocket::BindMode mode = QAbstractSocket::DefaultForPlatform);
+    
+    /**
+     * Sets the SOAP version to be used for any subsequent send message.
+     * \param version #SOAP1_1 or #SOAP1_2
+     * The default version is SOAP 1.2.
+     */
+    void setSoapVersion(KDSoap::SoapVersion version);
+
+public Q_SLOTS:
+    /**
+     * Send a SOAP-over-UDP message to IP address.  
+     * \param message  The actual message to be send. Use 
+     * KDSoapMessage::setMessageAddressingProperties() to set the WS-Addressing 
+     * properties of the message.
+     * \param headers can be used to add additional SOAP headers.
+     * \param address The address to send to message to. Messages send to a 
+     * multicast address will be send to to all interfaces.
+     * \param port The UDP port to send the message to
+     * \since 1.9
+     */    
+    bool sendMessage(const KDSoapMessage &message, const KDSoapHeaders &headers, const QHostAddress &address, quint16 port);
+    
+Q_SIGNALS:
+    /**
+     * emitted when a SOAP-over-UDP message is received over a bound socket. 
+     * KDSoapUdpClient doesn't do any filtering, so duplicate messages, spoofed 
+     * or responses to other requests will all be received. For example, if a 
+     * message is send via both IPv4 and IPv6, then the receivedMessage will be 
+     * emitted twice (with the same message, but with a different address)
+     * \param message The parsed message received over the socket. Use 
+     * KDSoapMessage::messageAddressingProperties() to see who the recipient is 
+     * and what SOAP action is requested.
+     * \param headers The additional headers of the message
+     * \param address The IP-address of the sender
+     * \param port The UDP port of the sender
+     * \see bind()
+     * \since 1.9
+     */
+    void receivedMessage(const KDSoapMessage &message, const KDSoapHeaders &headers, const QHostAddress &address, quint16 port);
+
+private:
+    KDSoapUdpClientPrivate *const d_ptr;
+    Q_DECLARE_PRIVATE(KDSoapUdpClient)
+};
+
+#endif // KDSOAPUDPCLIENT_H

--- a/src/KDSoapClient/KDSoapUdpClient_p.h
+++ b/src/KDSoapClient/KDSoapUdpClient_p.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019  Casper Meijn <casper@meijn.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KDSOAPUDPCLIENT_P_H
+#define KDSOAPUDPCLIENT_P_H
+
+#include <QObject>
+#include <QUdpSocket>
+
+class KDSoapUdpClientPrivate : public QObject
+{
+    Q_OBJECT
+public:
+    KDSoapUdpClientPrivate(KDSoapUdpClient *q) 
+        : q_ptr(q)
+    {}
+    
+    void receivedDatagram(const QByteArray &messageData, const QHostAddress &senderAddress, quint16 senderPort);
+    
+public Q_SLOTS:
+    void readyRead();
+    
+public:
+    QUdpSocket *socketIPv4;
+    QUdpSocket *socketIPv6;
+    KDSoap::SoapVersion soapVersion = KDSoap::SOAP1_2;
+
+private:
+    KDSoapUdpClient *const q_ptr;
+    Q_DECLARE_PUBLIC(KDSoapUdpClient)
+};
+
+#endif // KDSOAPUDPCLIENT_P_H

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_subdirectory(ws_addressing_support)
 add_subdirectory(ws_usernametoken_support)
 add_subdirectory(empty_element_wsdl)
 add_subdirectory(ws_discovery_wsdl)
+add_subdirectory(soap_over_udp)
 
 # These need internet access
 add_subdirectory(webcalls)

--- a/unittests/soap_over_udp/CMakeLists.txt
+++ b/unittests/soap_over_udp/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(soap_over_udp)
+
+set(KSWSDL2CPP_OPTION -use-local-files-only)
+set(WSDL_FILES wsdd-discovery-200901.wsdl)
+set(soap_over_udp_SRCS test_soap_over_udp.cpp wsdl_wsdd-discovery-200901.cpp)
+
+set(EXTRA_LIBS ${QT_QTXML_LIBRARY})
+
+add_unittest(${soap_over_udp_SRCS} )

--- a/unittests/soap_over_udp/docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-schema-os.xsd
+++ b/unittests/soap_over_udp/docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-schema-os.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) OASIS(r) 2009. All Rights Reserved.
+
+All capitalized terms in the following text have the meanings assigned to them in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full Policy may be found at the OASIS website.
+
+This document and translations of it may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to OASIS, except as needed for the purpose of developing any document or deliverable produced by an OASIS Technical Committee (in which case the rules applicable to copyrights, as set forth in the OASIS IPR Policy, must be followed) or as required to translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+OASIS requests that any OASIS Party or any other party that believes it has patent claims that would necessarily be infringed by implementations of this OASIS Committee Specification or OASIS Standard, to notify OASIS TC Administrator and provide an indication of its willingness to grant patent licenses to such patent claims in a manner consistent with the IPR Mode of the OASIS Technical Committee that produced this specification.
+
+OASIS invites any party to contact the OASIS TC Administrator if it is aware of a claim of ownership of any patent claims that would necessarily be infringed by implementations of this specification by a patent holder that is not willing to provide a license to such patent claims in a manner consistent with the IPR Mode of the OASIS Technical Committee that produced this specification. OASIS may include such claims on its website, but disclaims any obligation to do so.
+
+OASIS takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this document or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any effort to identify any such rights. Information on OASIS' procedures with respect to rights in any document or deliverable produced by an OASIS Technical Committee can be found on the OASIS website. Copies of claims of rights made available for publication and any assurances of licenses to be made available, or the result of an attempt made to obtain a general license or permission for the use of such proprietary rights by implementers or users of this OASIS Committee Specification or OASIS Standard, can be obtained from the OASIS TC Administrator. OASIS makes no representation that any information or list of intellectual property rights will at any time be complete, or that any claims in such list are, in fact, Essential Claims.
+
+The name "OASIS" is trademarks of OASIS, the owner and developer of this specification, and should be used only to refer to the organization and its official outputs. OASIS welcomes reference to, and implementation and use of, specifications, while reserving the right to enforce its marks against misleading uses. Please see http://www.oasis-open.org/who/trademark.php for above guidance.
+-->
+<xs:schema
+    targetNamespace="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+    xmlns:tns="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+    xmlns:wsa="http://www.w3.org/2005/08/addressing"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    blockDefault="#all" >
+
+  <xs:import
+      namespace="http://www.w3.org/2005/08/addressing"
+      schemaLocation="http://www.w3.org/2006/03/addressing/ws-addr.xsd" />
+
+  <!-- //////////////////// Discovery Messages //////////////////// -->
+
+  <xs:element name="Hello" type="tns:HelloType" />
+  <xs:complexType name="HelloType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Bye" type="tns:ByeType" />
+  <xs:complexType name="ByeType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Probe" type="tns:ProbeType" />
+  <xs:complexType name="ProbeType" >
+    <xs:sequence>
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="ProbeMatches" type="tns:ProbeMatchesType" />
+  <xs:complexType name="ProbeMatchesType" >
+    <xs:sequence>
+      <xs:element name="ProbeMatch"
+                  type="tns:ProbeMatchType"
+                  minOccurs="0"
+                  maxOccurs="unbounded" >
+      </xs:element>
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+  <xs:complexType name="ProbeMatchType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Resolve" type="tns:ResolveType" />
+  <xs:complexType name="ResolveType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="ResolveMatches" type="tns:ResolveMatchesType" />
+  <xs:complexType name="ResolveMatchesType" >
+    <xs:sequence>
+      <xs:element name="ResolveMatch" 
+                  type="tns:ResolveMatchType"
+                  minOccurs="0" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+  <xs:complexType name="ResolveMatchType" >
+    <xs:sequence>
+      <xs:element ref="wsa:EndpointReference" />
+      <xs:element ref="tns:Types" minOccurs="0" />
+      <xs:element ref="tns:Scopes" minOccurs="0" />
+      <xs:element ref="tns:XAddrs" minOccurs="0" />
+      <xs:element ref="tns:MetadataVersion" />
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType>
+
+  <xs:element name="Types" type="tns:QNameListType" />
+  <xs:simpleType name="QNameListType" >
+    <xs:list itemType="xs:QName" />
+  </xs:simpleType>
+
+  <xs:element name="Scopes" type="tns:ScopesType" />
+  <xs:complexType name="ScopesType" >
+    <xs:simpleContent>
+      <xs:extension base="tns:UriListType" >
+        <xs:attribute name="MatchBy" type="xs:anyURI" />
+        <xs:anyAttribute namespace="##other" processContents="lax" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="XAddrs" type="tns:UriListType" />
+  <xs:simpleType name="UriListType" >
+    <xs:list itemType="xs:anyURI" />
+  </xs:simpleType>
+
+  <xs:element name="MetadataVersion" type="xs:unsignedInt" />
+
+  <!-- //////////////////// Faults //////////////////// -->
+
+  <xs:simpleType name="FaultCodeType" >
+	<xs:restriction base="xs:QName" >
+	  <xs:enumeration value="tns:MatchingRuleNotSupported" />
+	</xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FaultCodeOpenType" >
+    <xs:union memberTypes="tns:FaultCodeType xs:QName" />
+  </xs:simpleType>
+
+  <xs:element name="SupportedMatchingRules" type="tns:UriListType" />
+
+  <!-- //////////////////// Compact Signature //////////////////// -->
+
+  <xs:attribute name="Id" type="xs:ID"/>
+
+  <xs:element name="Security" type="tns:SecurityType" />
+  <xs:complexType name="SecurityType" >
+    <xs:sequence>
+      <xs:element ref="tns:Sig" minOccurs="0" />
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType> 
+
+  <xs:element name="Sig" type="tns:SigType" />
+  <xs:complexType name="SigType" >
+    <xs:sequence>
+      <xs:any namespace="##other"
+              processContents="lax"
+              minOccurs="0"
+              maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="Scheme" type="xs:anyURI" use="required" />
+    <xs:attribute name="KeyId" type="xs:base64Binary" />
+    <xs:attribute name="Refs" type="xs:IDREFS" use="required" />
+    <xs:attribute name="Sig" type="xs:base64Binary" use="required" />
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:complexType> 
+
+  <!-- //////////////////// General Headers //////////////////// -->
+
+  <xs:element name="AppSequence" type="tns:AppSequenceType" />
+  <xs:complexType name="AppSequenceType" >
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType" >
+        <xs:attribute name="InstanceId"
+                      type="xs:unsignedInt"
+                      use="required" />
+        <xs:attribute name="SequenceId" type="xs:anyURI" />
+        <xs:attribute name="MessageNumber"
+                      type="xs:unsignedInt"
+                      use="required" />
+        <xs:anyAttribute namespace="##other" processContents="lax" />
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+</xs:schema>

--- a/unittests/soap_over_udp/test_soap_over_udp.cpp
+++ b/unittests/soap_over_udp/test_soap_over_udp.cpp
@@ -1,0 +1,173 @@
+/****************************************************************************
+** Copyright (C) 2019 Casper Meijn  <casper@meijn.net>
+** All rights reserved.
+**
+** This file is part of the KD Soap library.
+**
+** Licensees holding valid commercial KD Soap licenses may use this file in
+** accordance with the KD Soap Commercial License Agreement provided with
+** the Software.
+**
+**
+** This file may be distributed and/or modified under the terms of the
+** GNU Lesser General Public License version 2.1 and version 3 as published by the
+** Free Software Foundation and appearing in the file LICENSE.LGPL.txt included.
+**
+** This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+** WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+**
+** Contact info@kdab.com if any conditions of this licensing are not
+** clear to you.
+**
+**********************************************************************/
+
+#include "httpserver_p.h"
+#include "KDSoapUdpClient.h"
+#include "KDSoapUdpClient_p.h"
+#include "KDSoapMessage.h"
+#include <QNetworkDatagram>
+#include <QTest>
+#include <QSignalSpy>
+#include "wsdl_wsdd-discovery-200901.h"
+
+Q_DECLARE_METATYPE(QHostAddress)
+
+class SoapOverUdpTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase() {
+        qRegisterMetaType<KDSoapMessage>("KDSoapMessage");
+        qRegisterMetaType<KDSoapHeaders>("KDSoapHeaders");
+        qRegisterMetaType<QHostAddress>("QHostAddress");
+    }
+    
+    void testExample() {
+        // This is the example from the KDSoapUdpClient documentation. It is 
+        //   here for compile testing.
+        
+        auto soapUdpClient = new KDSoapUdpClient(this);
+        connect(soapUdpClient, &KDSoapUdpClient::receivedMessage, [=](const KDSoapMessage& message, const KDSoapHeaders& headers, const QHostAddress& address, quint16 port) { 
+            if(message.messageAddressingProperties().action() == QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ProbeMatches")) {
+                TNS__ProbeMatchesType probeMatches;
+                probeMatches.deserialize(message);
+                qDebug() << "Received probe match from" << address;
+            }
+        });
+        soapUdpClient->bind(3702);
+        
+        TNS__ProbeType probe;
+
+        KDSoapMessage message;
+        message = probe.serialize(QStringLiteral("Probe"));
+        message.setUse(KDSoapMessage::LiteralUse);
+        message.setNamespaceUri(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"));
+
+        KDSoapMessageAddressingProperties addressing;
+        addressing.setAction(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe"));
+        addressing.setMessageID(QStringLiteral("urn:uuid:") + QUuid::createUuid().toString(QUuid::WithoutBraces));
+        addressing.setDestination(QStringLiteral("urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01"));
+        addressing.setReplyEndpointAddress(KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous));
+        message.setMessageAddressingProperties(addressing);
+
+        soapUdpClient->sendMessage(message, KDSoapHeaders(), QHostAddress("239.255.255.250"), 3702);
+    }
+    
+    void testSendMessage() {
+        QUdpSocket testSocket;
+        bool rc = testSocket.bind();
+        QVERIFY(rc);
+        
+        KDSoapUdpClient udpClient;
+        
+        udpClient.sendMessage(exampleMessage(), KDSoapHeaders(), QHostAddress::LocalHost, testSocket.localPort());
+        
+        QVERIFY(testSocket.hasPendingDatagrams());
+        auto datagram = testSocket.receiveDatagram();
+        
+        QVERIFY(KDSoapUnitTestHelpers::xmlBufferCompare(datagram.data(), exampleTextData()));
+    }
+    
+    void testReceiveMessage() {
+        QUdpSocket testSocket;
+        
+        KDSoapUdpClient udpClient;
+        bool rc = udpClient.bind(12345);
+        QVERIFY(rc);
+        
+        QSignalSpy spy(&udpClient, SIGNAL(receivedMessage(KDSoapMessage, KDSoapHeaders, QHostAddress, quint16)));
+        
+        auto data = exampleTextData();
+        qint64 size = testSocket.writeDatagram(data, QHostAddress::LocalHost, 12345);
+        QCOMPARE(size, data.size());
+        
+        QVERIFY(spy.wait(1000));
+        QList<QVariant> arguments = spy.takeFirst();
+        QVERIFY(KDSoapUnitTestHelpers::xmlBufferCompare(arguments.at(0).value<KDSoapMessage>().toXml(), exampleMessage().toXml()));
+        QCOMPARE(arguments.at(1).value<KDSoapHeaders>().size(), 0);
+        QCOMPARE(arguments.at(2).value<QHostAddress>(), QHostAddress::LocalHost);
+    }
+    
+private:
+    QByteArray exampleTextData() {
+        return QByteArray(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" 
+            "<soap:Envelope"
+            "  xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\""
+            "  xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
+            "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+            "  xmlns:wsa=\"http://www.w3.org/2005/08/addressing\""
+            "  xmlns:soap-enc=\"http://www.w3.org/2003/05/soap-encoding\""
+            "  xmlns:n1=\"http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01\">"
+            "  <soap:Header>"
+            "    <wsa:To>urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01</wsa:To>"
+            "    <wsa:Action>http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe</wsa:Action>"
+            "    <wsa:MessageID>urn:uuid:0a6dc791-2be6-4991-9af1-454778a1917a</wsa:MessageID>"
+            "  </soap:Header>"
+            "  <soap:Body>"
+            "    <n1:Probe>"
+            "      <n1:Types xmlns:i=\"http://printer.example.org/2003/imaging\">i:PrintBasic</n1:Types>"
+            "      <n1:Scopes"
+            "        MatchBy=\"http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ldap\""
+            "        >ldap:///ou=engineering,o=examplecom,c=us</n1:Scopes>"
+            "    </n1:Probe>"
+            "  </soap:Body>"
+            "</soap:Envelope>");
+    }
+    
+    KDSoapMessage exampleMessage() {
+        TNS__ProbeType probe;
+        
+        KDQName type("i:PrintBasic");
+        type.setNameSpace("http://printer.example.org/2003/imaging");        
+        TNS__QNameListType types;
+        types.setEntries(QList<KDQName>() << type);
+        probe.setTypes(types);
+
+        TNS__UriListType scopeValues;
+        scopeValues.setEntries(QStringList() << "ldap:///ou=engineering,o=examplecom,c=us");
+        TNS__ScopesType scopes;
+        scopes.setValue(scopeValues);
+        scopes.setMatchBy("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ldap");
+        probe.setScopes(scopes);
+        
+        KDSoapMessage message;
+        message = probe.serialize(QStringLiteral("Probe"));
+        message.setUse(KDSoapMessage::LiteralUse);
+        message.setNamespaceUri(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"));
+
+        KDSoapMessageAddressingProperties addressing;
+        addressing.setAddressingNamespace(KDSoapMessageAddressingProperties::Addressing200508);
+        addressing.setAction(QStringLiteral("http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe"));
+        addressing.setMessageID(QStringLiteral("urn:uuid:0a6dc791-2be6-4991-9af1-454778a1917a"));
+        addressing.setDestination(QStringLiteral("urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01"));
+        message.setMessageAddressingProperties(addressing);
+        
+        return message;
+    }
+};
+
+QTEST_MAIN(SoapOverUdpTest)
+
+#include "test_soap_over_udp.moc"

--- a/unittests/soap_over_udp/wsdd-discovery-200901.wsdl
+++ b/unittests/soap_over_udp/wsdd-discovery-200901.wsdl
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) OASIS(r) 2009. All Rights Reserved.
+
+All capitalized terms in the following text have the meanings assigned to them in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full Policy may be found at the OASIS website.
+
+This document and translations of it may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to OASIS, except as needed for the purpose of developing any document or deliverable produced by an OASIS Technical Committee (in which case the rules applicable to copyrights, as set forth in the OASIS IPR Policy, must be followed) or as required to translate it into languages other than English.
+
+The limited permissions granted above are perpetual and will not be revoked by OASIS or its successors or assigns.
+
+This document and the information contained herein is provided on an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+OASIS requests that any OASIS Party or any other party that believes it has patent claims that would necessarily be infringed by implementations of this OASIS Committee Specification or OASIS Standard, to notify OASIS TC Administrator and provide an indication of its willingness to grant patent licenses to such patent claims in a manner consistent with the IPR Mode of the OASIS Technical Committee that produced this specification.
+
+OASIS invites any party to contact the OASIS TC Administrator if it is aware of a claim of ownership of any patent claims that would necessarily be infringed by implementations of this specification by a patent holder that is not willing to provide a license to such patent claims in a manner consistent with the IPR Mode of the OASIS Technical Committee that produced this specification. OASIS may include such claims on its website, but disclaims any obligation to do so.
+
+OASIS takes no position regarding the validity or scope of any intellectual property or other rights that might be claimed to pertain to the implementation or use of the technology described in this document or the extent to which any license under such rights might or might not be available; neither does it represent that it has made any effort to identify any such rights. Information on OASIS' procedures with respect to rights in any document or deliverable produced by an OASIS Technical Committee can be found on the OASIS website. Copies of claims of rights made available for publication and any assurances of licenses to be made available, or the result of an attempt made to obtain a general license or permission for the use of such proprietary rights by implementers or users of this OASIS Committee Specification or OASIS Standard, can be obtained from the OASIS TC Administrator. OASIS makes no representation that any information or list of intellectual property rights will at any time be complete, or that any claims in such list are, in fact, Essential Claims.
+
+The name "OASIS" is trademarks of OASIS, the owner and developer of this specification, and should be used only to refer to the organization and its official outputs. OASIS welcomes reference to, and implementation and use of, specifications, while reserving the right to enforce its marks against misleading uses. Please see http://www.oasis-open.org/who/trademark.php for above guidance.
+-->
+<wsdl:definitions
+    targetNamespace="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+    xmlns:tns="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+  <wsdl:types>
+    <xs:schema>
+      <xs:import
+          namespace="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01"
+          schemaLocation="http://docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-schema-os.xsd" />
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="HelloMessage" >
+    <wsdl:part name="parameters" element="tns:Hello" />
+  </wsdl:message>
+
+  <wsdl:message name="ByeMessage" >
+    <wsdl:part name="parameters" element="tns:Bye" />
+  </wsdl:message>
+
+  <wsdl:message name="ProbeMessage" >
+    <wsdl:part name="parameters" element="tns:Probe" />
+  </wsdl:message>
+
+  <wsdl:message name="ProbeMatchMessage" >
+    <wsdl:part name="parameters" element="tns:ProbeMatches" />
+  </wsdl:message>
+
+  <wsdl:message name="ResolveMessage" >
+    <wsdl:part name="parameters" element="tns:Resolve" />
+  </wsdl:message>
+
+  <wsdl:message name="ResolveMatchMessage" >
+    <wsdl:part name="parameters" element="tns:ResolveMatches" />
+  </wsdl:message>
+
+  <wsdl:portType name="TargetService" >
+    <wsdl:operation name="HelloOp" >
+      <wsdl:output message="tns:HelloMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Hello"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ByeOp" >
+      <wsdl:output message="tns:ByeMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Bye"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ProbeOp" >
+      <wsdl:input message="tns:ProbeMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ProbeMatchOp" >
+      <wsdl:output message="tns:ProbeMatchMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ProbeMatches"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ResolveOp" >
+      <wsdl:input message="tns:ResolveMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Resolve"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ResolveMatchOp" >
+      <wsdl:output message="tns:ResolveMatchMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ResolveMatches"
+      />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <!-- If this portType is included in Types, it indicates the 
+       Target Service is a Discovery Proxy operating in a managed mode. 
+       Discovery Proxies also implement tns:TargetService in an ad hoc mode.
+  -->
+  <wsdl:portType name="DiscoveryProxy">
+    <wsdl:operation name="HelloOp" >
+      <wsdl:input message="tns:HelloMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Hello"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ByeOp" >
+      <wsdl:input message="tns:ByeMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Bye"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ProbeOp" >
+      <wsdl:input message="tns:ProbeMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Probe"
+      />
+      <wsdl:output message="tns:ProbeMatchMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ProbeMatches"
+      />
+    </wsdl:operation>
+    <wsdl:operation name="ResolveOp" >
+      <wsdl:input message="tns:ResolveMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Resolve"
+      />
+      <wsdl:output message="tns:ResolveMatchMessage"
+      wsaw:Action
+      ="http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/ResolveMatches"
+      />
+    </wsdl:operation>
+  </wsdl:portType>
+</wsdl:definitions>

--- a/unittests/soap_over_udp/www.w3.org/2006/03/addressing/ws-addr.xsd
+++ b/unittests/soap_over_udp/www.w3.org/2006/03/addressing/ws-addr.xsd
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    W3C XML Schema defined in the Web Services Addressing 1.0 specification
+    http://www.w3.org/TR/ws-addr-core
+
+   Copyright © 2005 World Wide Web Consortium,
+
+   (Massachusetts Institute of Technology, European Research Consortium for
+   Informatics and Mathematics, Keio University). All Rights Reserved. This
+   work is distributed under the W3C® Software License [1] in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+   [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+   $Id: ws-addr.xsd,v 1.2 2008/07/23 13:38:16 plehegar Exp $
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2005/08/addressing" targetNamespace="http://www.w3.org/2005/08/addressing" blockDefault="#all" elementFormDefault="qualified" finalDefault="" attributeFormDefault="unqualified">
+	
+	<!-- Constructs from the WS-Addressing Core -->
+
+	<xs:element name="EndpointReference" type="tns:EndpointReferenceType"/>
+	<xs:complexType name="EndpointReferenceType" mixed="false">
+		<xs:sequence>
+			<xs:element name="Address" type="tns:AttributedURIType"/>
+			<xs:element ref="tns:ReferenceParameters" minOccurs="0"/>
+			<xs:element ref="tns:Metadata" minOccurs="0"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="ReferenceParameters" type="tns:ReferenceParametersType"/>
+	<xs:complexType name="ReferenceParametersType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="Metadata" type="tns:MetadataType"/>
+	<xs:complexType name="MetadataType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="MessageID" type="tns:AttributedURIType"/>
+	<xs:element name="RelatesTo" type="tns:RelatesToType"/>
+	<xs:complexType name="RelatesToType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="RelationshipType" type="tns:RelationshipTypeOpenEnum" use="optional" default="http://www.w3.org/2005/08/addressing/reply"/>
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:simpleType name="RelationshipTypeOpenEnum">
+		<xs:union memberTypes="tns:RelationshipType xs:anyURI"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="RelationshipType">
+		<xs:restriction base="xs:anyURI">
+			<xs:enumeration value="http://www.w3.org/2005/08/addressing/reply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="ReplyTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="From" type="tns:EndpointReferenceType"/>
+	<xs:element name="FaultTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="To" type="tns:AttributedURIType"/>
+	<xs:element name="Action" type="tns:AttributedURIType"/>
+
+	<xs:complexType name="AttributedURIType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<!-- Constructs from the WS-Addressing SOAP binding -->
+
+	<xs:attribute name="IsReferenceParameter" type="xs:boolean"/>
+	
+	<xs:simpleType name="FaultCodesOpenEnumType">
+		<xs:union memberTypes="tns:FaultCodesType xs:QName"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="FaultCodesType">
+		<xs:restriction base="xs:QName">
+			<xs:enumeration value="tns:InvalidAddressingHeader"/>
+			<xs:enumeration value="tns:InvalidAddress"/>
+			<xs:enumeration value="tns:InvalidEPR"/>
+			<xs:enumeration value="tns:InvalidCardinality"/>
+			<xs:enumeration value="tns:MissingAddressInEPR"/>
+			<xs:enumeration value="tns:DuplicateMessageID"/>
+			<xs:enumeration value="tns:ActionMismatch"/>
+			<xs:enumeration value="tns:MessageAddressingHeaderRequired"/>
+			<xs:enumeration value="tns:DestinationUnreachable"/>
+			<xs:enumeration value="tns:ActionNotSupported"/>
+			<xs:enumeration value="tns:EndpointUnavailable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="RetryAfter" type="tns:AttributedUnsignedLongType"/>
+	<xs:complexType name="AttributedUnsignedLongType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:unsignedLong">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemHeaderQName" type="tns:AttributedQNameType"/>
+	<xs:complexType name="AttributedQNameType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:QName">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemIRI" type="tns:AttributedURIType"/>
+	
+	<xs:element name="ProblemAction" type="tns:ProblemActionType"/>
+	<xs:complexType name="ProblemActionType" mixed="false">
+		<xs:sequence>
+			<xs:element ref="tns:Action" minOccurs="0"/>
+			<xs:element name="SoapAction" minOccurs="0" type="xs:anyURI"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+</xs:schema>


### PR DESCRIPTION
KDSoapUdpClient provides an interface for implementing a
SOAP-over-UDP[1] client.

It includes tests and documentation. I tested it with (kdsoap-ws-discovery-client)[https://gitlab.com/caspermeijn/kdsoap-ws-discovery-client].

Fixes #175 

[1] https://docs.oasis-open.org/ws-dd/soapoverudp/1.1/os/wsdd-soapoverudp-1.1-spec-os.html