### PR TITLE
[kdwsdl2cpp]Add option for loading PKCS12 certificates

### DIFF
--- a/kdwsdl2cpp/common/fileprovider.cpp
+++ b/kdwsdl2cpp/common/fileprovider.cpp
@@ -106,6 +106,15 @@ bool FileProvider::get( const QUrl &url, QString &target )
 
     QNetworkAccessManager manager;
     QNetworkRequest request(url);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    if (Settings::self()->certificateLoaded()) {
+        QSslConfiguration sslConfig = request.sslConfiguration();
+        sslConfig.setPrivateKey(Settings::self()->sslKey());
+        sslConfig.setLocalCertificate(Settings::self()->certificate());
+        sslConfig.setCaCertificates(Settings::self()->caCertificates());
+        request.setSslConfiguration(sslConfig);
+    }
+#endif
     QNetworkReply* job = manager.get(request);
 
     QEventLoop loop;

--- a/kdwsdl2cpp/src/main.cpp
+++ b/kdwsdl2cpp/src/main.cpp
@@ -67,6 +67,12 @@ static void showHelp(const char *appName)
             "                            use of the import-path option\n"
             "  -help-on-missing          When groups or basic types could not be found, display\n"
             "                            available types (helps with wrong namespaces)\n"
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+            "  -pkcs12file               Load a certificate from a PKCS12 file. You can use this option\n"
+            "                            if the WSDL file (or files refering to it) is served from a \n"
+            "                            location which require certificate based authentication\n"
+            "  -pkcs12password           Pass the password for the certificate file if required\n"
+#endif
             "\n", appName, appName, appName);
 }
 
@@ -90,6 +96,7 @@ int main(int argc, char **argv)
     QStringList importPathList;
     bool useLocalFilesOnly = false;
     bool helpOnMissing = false;
+    QString pkcs12File, pkcs12Password;
 
     int arg = 1;
     while (arg < argc) {
@@ -207,6 +214,22 @@ int main(int argc, char **argv)
             useLocalFilesOnly = true;
         } else if (opt == QLatin1String("-help-on-missing")) {
             helpOnMissing = true;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+        } else if (opt == QLatin1String("-pkcs12file")) {
+            ++arg;
+            if (!argv[arg]) {
+                showHelp(argv[0]);
+                return 1;
+            }
+            pkcs12File = QLatin1String(argv[arg]);
+        } else if (opt == QLatin1String("-pkcs12password")) {
+            ++arg;
+            if (!argv[arg]) {
+                showHelp(argv[0]);
+                return 1;
+            }
+            pkcs12Password = QLatin1String(argv[arg]);
+#endif
         } else if (!fileName) {
             fileName = argv[arg];
         } else {
@@ -262,6 +285,12 @@ int main(int argc, char **argv)
     Settings::self()->setHelpOnMissing(helpOnMissing);
 
     KWSDL::Compiler compiler;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    if (!pkcs12File.isEmpty()) {
+        if (!Settings::self()->loadCertificate(pkcs12File, pkcs12Password))
+            return -1;
+    }
+#endif
 
     // so that we have an event loop, for downloads
     QTimer::singleShot(0, &compiler, SLOT(run()));

--- a/kdwsdl2cpp/src/settings.cpp
+++ b/kdwsdl2cpp/src/settings.cpp
@@ -251,3 +251,51 @@ bool Settings::helpOnMissing() const
 {
     return mHelpOnMissing;
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+bool Settings::loadCertificate(const QString &certPath, const QString & password)
+{
+    QFile certFile(certPath);
+    if (certFile.open(QFile::ReadOnly)) {
+        mCertificateLoaded = QSslCertificate::importPkcs12(&certFile,
+                                                     &mSslKey,
+                                                     &mCertificate,
+                                                     &mCaCertificates,
+                                                     password.toLocal8Bit());
+        certFile.close();
+        if (!mCertificateLoaded) {
+            fprintf(stderr, "Unable to load the %s certificate file\n",
+                    certPath.toLocal8Bit().constData());
+            if (!password.isEmpty())
+                fprintf(stderr, "Please make sure that you have passed the correct password\n");
+            else
+                fprintf(stderr, "Maybe it is password protected?\n");
+        }
+        return mCertificateLoaded;
+    } else {
+        fprintf(stderr, "Failed to open the %s certificate file for reading\n",
+                certPath.toLocal8Bit().constData());
+    }
+    return false;
+}
+
+QList<QSslCertificate> Settings::caCertificates() const
+{
+    return mCaCertificates;
+}
+
+QSslCertificate Settings::certificate() const
+{
+    return mCertificate;
+}
+
+QSslKey Settings::sslKey() const
+{
+    return mSslKey;
+}
+
+bool Settings::certificateLoaded() const
+{
+    return mCertificateLoaded;
+}
+#endif

--- a/kdwsdl2cpp/src/settings.h
+++ b/kdwsdl2cpp/src/settings.h
@@ -21,6 +21,8 @@
 #define SETTINGS_H
 
 #include <QMap>
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QStringList>
 #include <QUrl>
 
@@ -85,6 +87,14 @@ public:
     bool helpOnMissing() const;
     void setHelpOnMissing(bool b);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    bool loadCertificate(const QString & certPath, const QString &password = QString());
+    bool certificateLoaded() const;
+    QSslKey sslKey() const;
+    QSslCertificate certificate() const;
+    QList<QSslCertificate> caCertificates() const;
+#endif
+
 private:
     friend class SettingsSingleton;
     Settings();
@@ -105,6 +115,12 @@ private:
     bool mKeepUnusedTypes;
     bool mUseLocalFilesOnly;
     bool mHelpOnMissing;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    QSslKey mSslKey;
+    QSslCertificate mCertificate;
+    QList<QSslCertificate> mCaCertificates;
+    bool mCertificateLoaded = false;
+#endif
 };
 
 #endif


### PR DESCRIPTION
I needed to interact with a web service protected with PKCS12 based certificate. 
To parse the WSDL files from these servers I added two command line arguments to the kdwsdl2cpp to being able to load a certificate file. 

Ps. because the QSslCertificate::importPkcs12 is only supported above Qt 5.4 and newer I have added guards around the new functionality. 