### PR TITLE
[kdwsdl2cpp]Add option for loading PKCS12 certificates

### DIFF
--- a/kdwsdl2cpp/common/fileprovider.cpp
+++ b/kdwsdl2cpp/common/fileprovider.cpp
@@ -106,6 +106,15 @@ bool FileProvider::get( const QUrl &url, QString &target )
 
     QNetworkAccessManager manager;
     QNetworkRequest request(url);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    if (Settings::self()->certificateLoaded()) {
+        QSslConfiguration sslConfig = request.sslConfiguration();
+        sslConfig.setPrivateKey(Settings::self()->sslKey());
+        sslConfig.setLocalCertificate(Settings::self()->certificate());
+        sslConfig.setCaCertificates(Settings::self()->caCertificates());
+        request.setSslConfiguration(sslConfig);
+    }
+#endif
     QNetworkReply* job = manager.get(request);
 
     QEventLoop loop;

--- a/kdwsdl2cpp/src/settings.cpp
+++ b/kdwsdl2cpp/src/settings.cpp
@@ -251,3 +251,51 @@ bool Settings::helpOnMissing() const
 {
     return mHelpOnMissing;
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+bool Settings::loadCertificate(const QString &certPath, const QString & password)
+{
+    QFile certFile(certPath);
+    if (certFile.open(QFile::ReadOnly)) {
+        mCertificateLoaded = QSslCertificate::importPkcs12(&certFile,
+                                                     &mSslKey,
+                                                     &mCertificate,
+                                                     &mCaCertificates,
+                                                     password.toLocal8Bit());
+        certFile.close();
+        if (!mCertificateLoaded) {
+            fprintf(stderr, "Unable to load the %s certificate file\n",
+                    certPath.toLocal8Bit().constData());
+            if (!password.isEmpty())
+                fprintf(stderr, "Please make sure that you have passed the correct password\n");
+            else
+                fprintf(stderr, "Maybe it is password protected?\n");
+        }
+        return mCertificateLoaded;
+    } else {
+        fprintf(stderr, "Failed to open the %s certificate file for reading\n",
+                certPath.toLocal8Bit().constData());
+    }
+    return false;
+}
+
+QList<QSslCertificate> Settings::caCertificates() const
+{
+    return mCaCertificates;
+}
+
+QSslCertificate Settings::certificate() const
+{
+    return mCertificate;
+}
+
+QSslKey Settings::sslKey() const
+{
+    return mSslKey;
+}
+
+bool Settings::certificateLoaded() const
+{
+    return mCertificateLoaded;
+}
+#endif

--- a/kdwsdl2cpp/src/settings.h
+++ b/kdwsdl2cpp/src/settings.h
@@ -21,6 +21,8 @@
 #define SETTINGS_H
 
 #include <QMap>
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QStringList>
 #include <QUrl>
 
@@ -85,6 +87,14 @@ public:
     bool helpOnMissing() const;
     void setHelpOnMissing(bool b);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    bool loadCertificate(const QString & certPath, const QString &password = QString());
+    bool certificateLoaded() const;
+    QSslKey sslKey() const;
+    QSslCertificate certificate() const;
+    QList<QSslCertificate> caCertificates() const;
+#endif
+
 private:
     friend class SettingsSingleton;
     Settings();
@@ -105,6 +115,12 @@ private:
     bool mKeepUnusedTypes;
     bool mUseLocalFilesOnly;
     bool mHelpOnMissing;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    QSslKey mSslKey;
+    QSslCertificate mCertificate;
+    QList<QSslCertificate> mCaCertificates;
+    bool mCertificateLoaded = false;
+#endif
 };
 
 #endif


### PR DESCRIPTION
I needed to interact with a web service protected with PKCS12 based certificate.
To parse the WSDL files from these servers I added two command line arguments to the kdwsdl2cpp to being able to load a certificate file.

Ps. because the QSslCertificate::importPkcs12 is only supported above Qt 5.4 and newer I have added guards around the new functionality.

@dfaure-kdab , @caspermeijn this is the same modification what I have submitted in PR #187 (plus the David requested warning in the help), but somehow I cannot amend and push it anymore (it shows an unknown repository as  source): 
![kép](https://user-images.githubusercontent.com/1609182/67522188-92d8cb80-f6ac-11e9-8299-01a0afebe797.png)

