### PR TITLE
add qmake support for soap over udp

### DIFF
--- a/src/KDSoapClient/KDSoapClient.pro
+++ b/src/KDSoapClient/KDSoapClient.pro
@@ -24,14 +24,16 @@ INSTALLHEADERS = KDSoapMessage.h \
     KDDateTime.h \
     KDSoapFaultException.h \
     KDSoapMessageAddressingProperties.cpp \
-    KDSoapEndpointReference.cpp
+    KDSoapEndpointReference.cpp \
+    KDSoapUdpClient.h
 PRIVATEHEADERS = KDSoapPendingCall_p.h \
     KDSoapPendingCallWatcher_p.h \
     KDSoapClientInterface_p.h \
     KDSoapClientThread_p.h \
     KDSoapMessageReader_p.h \
     KDSoapMessageWriter_p.h \
-    KDSoapNamespacePrefixes_p.h
+    KDSoapNamespacePrefixes_p.h \
+    KDSoapUdpClient_p.h
 HEADERS = $$INSTALLHEADERS \
     $$PRIVATEHEADERS \
     KDSoapReplySslHandler_p.h \
@@ -56,6 +58,7 @@ SOURCES = KDSoapMessage.cpp \
     KDSoapMessageAddressingProperties.cpp \
     KDSoapEndpointReference.cpp \
     KDQName.cpp \
+    KDSoapUdpClient.cpp \
 
 
 DEFINES += KDSOAP_BUILD_KDSOAP_LIB

--- a/src/KDSoapClient/KDSoapUdpClient_p.h
+++ b/src/KDSoapClient/KDSoapUdpClient_p.h
@@ -21,6 +21,8 @@
 #include <QObject>
 #include <QUdpSocket>
 
+#include "KDSoapUdpClient.h"
+
 class KDSoapUdpClientPrivate : public QObject
 {
     Q_OBJECT

--- a/src/KDSoapClient/KDSoapUdpClient_p.h
+++ b/src/KDSoapClient/KDSoapUdpClient_p.h
@@ -28,12 +28,12 @@ public:
     KDSoapUdpClientPrivate(KDSoapUdpClient *q) 
         : q_ptr(q)
     {}
-    
+
     void receivedDatagram(const QByteArray &messageData, const QHostAddress &senderAddress, quint16 senderPort);
-    
+
 public Q_SLOTS:
     void readyRead();
-    
+
 public:
     QUdpSocket *socketIPv4;
     QUdpSocket *socketIPv6;

--- a/unittests/soap_over_udp/soap_over_udp.pro
+++ b/unittests/soap_over_udp/soap_over_udp.pro
@@ -1,0 +1,10 @@
+KDWSDL_OPTIONS = -use-local-files-only
+include( $${TOP_SOURCE_DIR}/unittests/unittests.pri )
+QT += xml
+SOURCES = test_soap_over_udp.cpp
+test.target = test
+test.commands = ./$(TARGET)
+test.depends = $(TARGET)
+QMAKE_EXTRA_TARGETS += test
+
+KDWSDL = wsdd-discovery-200901.wsdl

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -50,7 +50,8 @@ SUBDIRS = \
   ws_addressing_support \
   ws_usernametoken_support \
   list_restriction \
-  QSharedPointer_include
+  QSharedPointer_include \
+  soap_over_udp
 
 # These need internet access
 SUBDIRS += webcalls webcalls_wsdl


### PR DESCRIPTION
was missing in e0a3bbce1e527f3a5734adb66628b264176faf70 which introduced
soap over udp but neglected to add it to qmake