### PR TITLE
fix spec compliance

### DIFF
--- a/unittests/ws_addressing_support/wsaddressingtest.cpp
+++ b/unittests/ws_addressing_support/wsaddressingtest.cpp
@@ -53,9 +53,15 @@ private Q_SLOTS:
 
         QString unspecified = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Unspecified);
         QCOMPARE(unspecified, QString("http://www.w3.org/2005/08/addressing/unspecified"));
-        
-        QString none200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::None, KDSoapMessageAddressingProperties::Addressing200303);
-        QCOMPARE(none200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/none"));
+
+        QString reply200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Reply, KDSoapMessageAddressingProperties::Addressing200303);
+        QCOMPARE(reply200303, QString()); // Reply is not a thing in older than 2005/08
+
+        QString anon200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Anonymous, KDSoapMessageAddressingProperties::Addressing200303);
+        QCOMPARE(anon200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/role/anonymous"));
+
+        QString unspecified200303 = KDSoapMessageAddressingProperties::predefinedAddressToString(KDSoapMessageAddressingProperties::Unspecified, KDSoapMessageAddressingProperties::Addressing200303);
+        QCOMPARE(unspecified200303, QString("http://schemas.xmlsoap.org/ws/2003/03/addressing/id/unspecified"));
     }
 
     void shouldWriteAProperSoapMessageWithRightsAddressingProperties()


### PR DESCRIPTION
as per https://www.w3.org/Submission/ws-addressing/ the only well-known
uri in 2004/08 was anonymous and it has a role prefix. from the
implicit reading I can find on earlier versions the same applies to them.

so, when constructing the well-known URIs inject a role prefix when
dealing with specs up to 2004/08 and raise a warning when attempting to
use anything but anonymous

same for /id/unspecified

(recreates #180 which broke for reasons :flushed:)