### PR TITLE
set the cmake install interface directories on the library targets

### DIFF
--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SOURCES
 add_library(kdsoap ${KDSoap_LIBRARY_MODE} ${SOURCES})
 target_link_libraries(kdsoap ${QT_LIBRARIES})
 set_target_properties(kdsoap PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_include_directories(kdsoap INTERFACE "$<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>")
 
 # append d to debug libraries for windows builds
 if(WIN32)

--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -30,6 +30,7 @@ set_source_files_properties(KDSoapServerObjectInterface.cpp PROPERTIES SKIP_AUTO
 add_library(kdsoap-server ${KDSoap_LIBRARY_MODE} ${SOURCES})
 target_link_libraries(kdsoap-server kdsoap ${QT_LIBRARIES})
 set_target_properties(kdsoap-server PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_include_directories(kdsoap-server INTERFACE "$<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>")
 
 # append d to debug libraries for windows builds
 if(WIN32)


### PR DESCRIPTION
the cmake package gets imported targets generated for use by API consumers.

so they can do

```
target_link_libraries(myapp KDSoap::kdsoap)
```

in their cmake code and because KDSoap::kdsoap is an imported target cmake
automatically knows where to find the library. alas, since we didn't
set an interface directory cmake did not know where to find the relevant
headers.
this isn't a problem so long as they are in one of the standard search
paths (e.g. /usr/include), but when the are installed elsewhere (e.g.
/opt/kdsoap/include) they will not be found.

by explicitly setting the INSTALL_INTERFACE to INSTALL_INCLUDE_DIR the
generated KDSoapTargets.cmake will set the relevant path on the target
and thus allow idiomatic use of the imported target without having to
mess with include dirs manually.