### PR TITLE
Add support for WS:Addressing in KDSoapClient

### DIFF
--- a/src/KDSoapClient/KDSoapClientInterface.h
+++ b/src/KDSoapClient/KDSoapClientInterface.h
@@ -338,9 +338,49 @@ public:
      */
     void setTimeout(int msecs);
 
+    /**
+     * \brief setSendSoapActionInHttpHeader
+     * \param sendInHttpHeader
+     * This option can be used to enable/disable the sending of the SOAP action parameter
+     * in the Content-Type HTTP header (in the case of SOAP 1.2 requests).
+     * It might be necessary to disable it for certain  SOAP server implementations
+     * in the case if the action is passed in the SOAP envelope's header with WS-Addressing.
+     * \since 1.11
+     */
+    void setSendSoapActionInHttpHeader(bool sendInHttpHeader);
+
+    /**
+     * \brief sendActionInHTTP_Header
+     * \return true if the SOAP action is passed in the HTTP Content-Type of the request.
+     * This parameter is used only in the case of SOAP 1.2 requests.
+     * This option is enabled by default.
+     * \since 1.11
+     */
+    bool sendSoapActionInHttpHeader() const;
+
+    /**
+     * \brief setSendSoapActionInWsAddressingHeader
+     * \param sendInWsAddressingHeader
+     * This function can be used to enable/disable the sending of the SOAP action embedded to
+     * the request's SOAP envelope header. See the headers of the WS-Addressing:
+     * https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/messaging-protocols#message-addressing-headers
+     * \since 1.11
+     */
+    void setSendSoapActionInWsAddressingHeader(bool sendInWsAddressingHeader);
+
+    /**
+     * \brief sendSoapActionInWsAddressingHeader
+     * \return true if the SOAP action is embedded to the request's SOAP envelope
+     * header. See the headers of the WS-Addressing:
+     * https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/messaging-protocols#message-addressing-headers
+     * This option is disabled by default, the SOAP action is sent in the Conten-Type HTTP header.
+     * See setSendHTTPActionParameter for more details.
+     * \since 1.11
+     */
+    bool sendSoapActionInWsAddressingHeader() const;
+
 private:
     friend class KDSoapThreadTask;
-
     KDSoapClientInterfacePrivate *const d;
 };
 

--- a/src/KDSoapClient/KDSoapClientInterface_p.h
+++ b/src/KDSoapClient/KDSoapClientInterface_p.h
@@ -56,12 +56,13 @@ public:
     KDSoapSslHandler *m_sslHandler;
 #endif
     int m_timeout;
+    bool m_sendSoapActionInHttpHeader = true;
+    bool m_sendSoapActionInWsAddressingHeader = false;
 
     QNetworkAccessManager *accessManager();
     QNetworkRequest prepareRequest(const QString &method, const QString &action);
-    QBuffer *prepareRequestBuffer(const QString &method, const KDSoapMessage &message, const KDSoapHeaders &headers);
-    void writeElementContents(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const KDSoapValue &element,
-                              KDSoapMessage::Use use);
+    QBuffer *prepareRequestBuffer(const QString &method, const KDSoapMessage &message, const QString &soapAction, const KDSoapHeaders &headers);
+    void writeElementContents(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const KDSoapValue &element, KDSoapMessage::Use use);
     void writeChildren(KDSoapNamespacePrefixes &namespacePrefixes, QXmlStreamWriter &writer, const KDSoapValueList &args, KDSoapMessage::Use use);
     void writeAttributes(QXmlStreamWriter &writer, const QList<KDSoapValue> &attributes);
     void setupReply(QNetworkReply *reply);

--- a/src/KDSoapClient/KDSoapClientThread.cpp
+++ b/src/KDSoapClient/KDSoapClientThread.cpp
@@ -94,7 +94,10 @@ void KDSoapThreadTask::process(QNetworkAccessManager &accessManager)
 
     accessManager.setProxy(m_data->m_iface->d->accessManager()->proxy());
 
-    QBuffer *buffer = m_data->m_iface->d->prepareRequestBuffer(m_data->m_method, m_data->m_message, m_data->m_headers);
+    QBuffer *buffer = m_data->m_iface->d->prepareRequestBuffer(m_data->m_method,
+                                                               m_data->m_message,
+                                                               m_data->m_action,
+                                                               m_data->m_headers);
     QNetworkRequest request = m_data->m_iface->d->prepareRequest(m_data->m_method, m_data->m_action);
     QNetworkReply *reply = accessManager.post(request, buffer);
     m_data->m_iface->d->setupReply(reply);

--- a/testtools/httpserver_p.h
+++ b/testtools/httpserver_p.h
@@ -39,7 +39,9 @@ bool xmlBufferCompare(const QByteArray &source, const QByteArray &dest);
 void httpGet(const QUrl &url);
 bool setSslConfiguration();
 const char *xmlEnvBegin11();
+const char *xmlEnvBegin11WithWSAddressing();
 const char *xmlEnvBegin12();
+const char *xmlEnvBegin12WithWSAddressing();
 const char *xmlEnvEnd();
 }
 
@@ -111,6 +113,44 @@ public:
         return m_headers.value(value);
     }
 
+    /**
+     * @brief clientUseWSAddressing
+     * @return
+     * Returns true if the server expects clients to use WS-Addressing.
+     */
+    bool clientSendsActionInHttpHeader() const;
+
+    /**
+     * @brief setClientSendsActionInHttpHeader
+     * @param clientSendsActionInHttpHeader
+     * If this function is called with clientSendsActionInHttpHeader set to false then
+     * (in the case of SOAP 1.2 requests) the Content-type HTTP header will not checked
+     * for containing the proper SOAP action. In this case the client should send the SOAP action
+     * embedded to the SOAP envelope's header section).
+     */
+    void setClientSendsActionInHttpHeader(bool clientSendsActionInHttpHeader);
+
+    /**
+     * @brief setExpectedSoapAction
+     * @param expectedSoapAction
+     * This function could be used to specify the expected SOAP action in the incoming request's header.
+     * In the case of SOAP 1.1 requests the SOAP action should be in the SoapAction HTTP header,
+     * in the case of SOAP 1.2 requests the SOAP action is sent in the Content-Type HTTP header's
+     * action parameter. Please note if setClientSendsActionInHttpHeader is called with false argument
+     * then this check is skipped. (In this case the SOAP action should be passed in the envelope's
+     * header). To disable the SOAP action checking call this function with an empty expectedSoapAction
+     * parameter. (This is the default behaviour of the HttpServerThread).
+     */
+    void setExpectedSoapAction(const QByteArray &expectedSoapAction);
+
+    /**
+     * @brief expectedSoapAction
+     * @return the expected SOAP action against which the request's headers will be checked.
+     * If the function returns an empty string then the SOAP actions of the incoming requests
+     * will not be checked.
+     */
+    QByteArray expectedSoapAction() const;
+
 protected:
     /* \reimp */ void run() override;
 
@@ -180,6 +220,8 @@ private:
 
     Features m_features;
     BlockingHttpServer *m_server;
+    bool m_clientSendsActionInHttpHeader = true;
+    QByteArray m_expectedSoapAction;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(HttpServerThread::Features)

--- a/unittests/builtinhttp/builtinhttp.cpp
+++ b/unittests/builtinhttp/builtinhttp.cpp
@@ -407,6 +407,43 @@ private Q_SLOTS:
         }
     }
 
+    // Test if the setClientSendsActionInHttpHeader is set false in the client then the SOAP action
+    // is really not placed into the Content-Type HTTP header
+    void testSetClientSendsActionInHttpHeader()
+    {
+        HttpServerThread server(countryResponse(), HttpServerThread::Public);
+        server.setClientSendsActionInHttpHeader(false);
+
+        qDebug() << "server ready, proceeding" << server.endPoint();
+        KDSoapClientInterface client(server.endPoint(), countryMessageNamespace());
+        client.setSendSoapActionInHttpHeader(false);
+        client.setSoapVersion(KDSoapClientInterface::SOAP1_2);
+        QString action = QStringLiteral("http://localhost/getEmployeeCountry");
+        server.setExpectedSoapAction(action.toLocal8Bit());
+        KDSoapMessage ret= client.call(QStringLiteral("getEmployeeCountry"), countryMessage(), action);
+        QVERIFY(!ret.isFault());
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedCountryRequest12()));
+        QCOMPARE(server.header("Content-Type").constData(), "application/soap+xml;charset=utf-8");
+    }
+
+    // Test if the setSendSoapActionInWsAddressingHeader is set true in the client then the SOAP action
+    // is really placed in the SOAP envelope's header section
+    void testSendSoapActionWithWSAddressing()
+    {
+        HttpServerThread server(countryResponse(), HttpServerThread::Public);
+
+        qDebug() << "server ready, proceeding" << server.endPoint();
+        KDSoapClientInterface client(server.endPoint(), countryMessageNamespace());
+        client.setSendSoapActionInWsAddressingHeader(true);
+        client.setSoapVersion(KDSoapClientInterface::SOAP1_2);
+        QString action = QStringLiteral("http://localhost/getEmployeeCountry");
+        server.setExpectedSoapAction(action.toLocal8Bit());
+        KDSoapMessage ret= client.call(QStringLiteral("getEmployeeCountry"), countryMessage(), action);
+        QVERIFY(!ret.isFault());
+        QVERIFY(xmlBufferCompare(server.receivedData(), expectedCountryRequestWithWSAddressingAction()));
+    }
+
+    
 private:
     static QByteArray countryResponse()
     {
@@ -426,6 +463,25 @@ private:
               "</n1:getEmployeeCountry>"
               "</soap:Body>"
             + xmlEnvEnd();
+    }
+    static QByteArray expectedCountryRequest12()
+    {
+        return QByteArray(xmlEnvBegin12()) +
+               "><soap:Body>"
+               "<n1:getEmployeeCountry xmlns:n1=\"http://www.kdab.com/xml/MyWsdl/\">"
+               "<employeeName>David Ä Faure</employeeName>"
+               "</n1:getEmployeeCountry>"
+               "</soap:Body>" + xmlEnvEnd();
+    }
+    static QByteArray expectedCountryRequestWithWSAddressingAction()
+    {
+        return QByteArray(xmlEnvBegin12WithWSAddressing()) +
+               "><soap:Header><wsa:Action>http://localhost/getEmployeeCountry</wsa:Action></soap:Header>"
+               "<soap:Body>"
+               "<n1:getEmployeeCountry>"
+               "<employeeName>David Ä Faure</employeeName>"
+               "</n1:getEmployeeCountry>"
+               "</soap:Body>" + xmlEnvEnd();
     }
     static QString countryMessageNamespace()
     {


### PR DESCRIPTION
If this option is enabled the action parameter (which is passed as an
url parameter by the current implementation) will be put to the message
header. 

I have tested it with a SOAP master implementation written in .NET.