### PR TITLE
[kdwsdl2cpp]Do not overwrite output files in the case their content unchanged

### DIFF
--- a/kdwsdl2cpp/libkode/printer.cpp
+++ b/kdwsdl2cpp/libkode/printer.cpp
@@ -22,6 +22,7 @@
 
 #include <QtCore/QFile>
 #include <QtCore/QStringList>
+#include <QtCore/QTextCodec>
 #include <QtCore/QTextStream>
 #include <QtCore/QFileInfo>
 #include <QDebug>
@@ -60,6 +61,16 @@ class Printer::Private
     QString mOutputDirectory;
     QString mSourceFile;
     QStringList mStatementsAfterIncludes;
+
+    /**
+     * @brief printCodeIntoFile
+     * Writes the string passed through the code parameter to the file referenced
+     * by the file parameter in the case if it differs from the content of the file pointed by the
+     * file parameter.
+     * @param code reference to a Code object which contents needs to be printed
+     * @param file the target file in unopened state with filename set
+     */
+    void printCodeIntoFile( const Code &code, QFile *file );
 };
 
 void Printer::Private::addLabel( Code& code, const QString& label )
@@ -804,16 +815,7 @@ void Printer::printHeader( const File &file )
 //  KSaveFile::simpleBackupFile( filename, QString(), ".backup" );
 
   QFile header( filename );
-  if ( !header.open( QIODevice::WriteOnly ) ) {
-    qWarning( "Can't open '%s' for writing.", qPrintable( filename ) );
-    return;
-  }
-
-  QTextStream h( &header );
-
-  h << out.text();
-
-  header.close();
+  d->printCodeIntoFile( out, &header );
 }
 
 void Printer::printImplementation( const File &file, bool createHeaderInclude )
@@ -945,16 +947,52 @@ void Printer::printImplementation( const File &file, bool createHeaderInclude )
     filename.prepend( d->mOutputDirectory + '/' );
 
   QFile implementation( filename );
-  if ( !implementation.open( QIODevice::WriteOnly ) ) {
-    qWarning( "Can't open '%s' for writing.", qPrintable( filename ) );
-    return;
+  d->printCodeIntoFile( out, &implementation );
+}
+
+void Printer::Private::printCodeIntoFile( const Code &code, QFile *file )
+{
+  const QString outText = code.text();
+  bool identical = true;
+  if ( file->exists() ) {
+    if ( !file->open( QIODevice::ReadOnly ) ) {
+      qWarning( "Can't open '%s' for reading.", qPrintable( file->fileName() ) );
+      return;
+    }
+
+    QTextStream fileReaderStream( file );
+    fileReaderStream.setCodec( QTextCodec::codecForName("UTF-8") );
+
+    QTextStream codeStream( outText.toUtf8() );
+    QString fileLine, outLine;
+    while ( fileReaderStream.readLineInto( &fileLine ) && codeStream.readLineInto(&outLine) ) {
+      if ( fileLine != outLine ) {
+        identical = false;
+        break;
+      }
+    }
+
+    if ( identical )
+      identical = fileReaderStream.atEnd() && codeStream.atEnd();
+    file->close();
+  } else {
+    identical = false;
   }
 
-  QTextStream h( &implementation );
+  if ( !identical ) {
+    if ( !file->open( QIODevice::WriteOnly ) ) {
+      qWarning( "Can't open '%s' for writing.", qPrintable( file->fileName() ) );
+      return;
+    }
 
-  h << out.text();
+    QTextStream fileWriterStream( file );
+    fileWriterStream.setCodec( QTextCodec::codecForName("UTF-8") );
+    fileWriterStream << outText;
 
-  implementation.close();
+    file->close();
+  } else {
+    qDebug("Skip generating %s because its content did not change", qPrintable( file->fileName() ));
+  }
 }
 
 #if 0 // TODO: port to cmake

--- a/kdwsdl2cpp/libkode/printer.h
+++ b/kdwsdl2cpp/libkode/printer.h
@@ -138,6 +138,12 @@ class KODE_EXPORT Printer
      */
     void setStatementsAfterIncludes(const QStringList &statements);
 
+    /**
+     * @brief setVerbose enable/disable outputting verbose logs
+     * @param verbose
+     */
+    void setVerbose( bool verbose );
+
   protected:
     /**
      * Returns the creation warning.


### PR DESCRIPTION
Mainly useful when tweaking kdwsdl2cpp because the generated files not
gooing to be modified if their contents did not changed. This could
reduce the compilation time of the projects including the generated
codes.

This change have been manually copied over from the kode's libkode where
it got reviewed by @dfaure-kdab:
https://github.com/cornelius/kode/pull/32