### PR TITLE
correct c++ syntax for localTypeForElement [2]

### DIFF
--- a/kdwsdl2cpp/src/typemap.cpp
+++ b/kdwsdl2cpp/src/typemap.cpp
@@ -307,6 +307,9 @@ QString TypeMap::localTypeForElement(const QName &elementName) const
 {
     QList<Entry>::ConstIterator it = elementEntry(elementName);
     if (it != mElementMap.constEnd()) {
+        if (!(*it).builtinType) {
+            return correctSyntaxCpp((*it).localType);
+        }
         return (*it).localType;
     }
 


### PR DESCRIPTION
fixes #210

Now also tested with the ihc_wsdl, one wsdl matching the issue and some of my local ones.