### PR TITLE
Fix missing libkode -> code_generation renames

### DIFF
--- a/kdwsdl2cpp/src/kdwsdl2cpp.pro
+++ b/kdwsdl2cpp/src/kdwsdl2cpp.pro
@@ -22,7 +22,7 @@ win32-msvc*:PRE_TARGETDEPS += $${TOP_BUILD_DIR}/lib/kode.lib \
     $${TOP_BUILD_DIR}/lib/xmlschema.lib \
     $${TOP_BUILD_DIR}/lib/xmlcommon.lib
 LIBS += -L$${TOP_BUILD_DIR}/lib \
-        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/libkode \
+        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/code_generation \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/schema \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/common \
     -l$${KDWSDL2CPP_LIB} \

--- a/kdwsdl2cpp/src/kdwsdl2cpp_lib.pro
+++ b/kdwsdl2cpp/src/kdwsdl2cpp_lib.pro
@@ -33,7 +33,7 @@ win32-msvc*:PRE_TARGETDEPS += $${TOP_BUILD_DIR}/lib/kode.lib \
     $${TOP_BUILD_DIR}/lib/xmlschema.lib \
     $${TOP_BUILD_DIR}/lib/xmlcommon.lib
 LIBS += -L$${TOP_BUILD_DIR}/lib \
-        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/libkode \
+        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/code_generation \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/schema \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/common \
     -lkode \

--- a/unittests/unittests.pri
+++ b/unittests/unittests.pri
@@ -18,7 +18,7 @@ DEPENDPATH += $${TOP_SOURCE_DIR}/testtools \
 DEBUG_SUFFIX=""
 CONFIG(debug, debug|release):!unix: DEBUG_SUFFIX = d
 LIBS += -L$${TOP_BUILD_DIR}/lib \
-        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/libkode \
+        -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/code_generation \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/schema \
         -L$${TOP_BUILD_DIR}/kdwsdl2cpp/libkode/common \
         -ltesttools$$DEBUG_SUFFIX


### PR DESCRIPTION
I have managed to miss the renaming a couple of references in qmake project files to the libkode/libkode -> libkode/code_generation. This PR fixes these references.