### PR TITLE
Fix PKCS12 certificate loading

### DIFF
--- a/kdwsdl2cpp/src/main.cpp
+++ b/kdwsdl2cpp/src/main.cpp
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
             }
 
             // set the loaded certificate info as default SSL config
-            QSslConfiguration sslConfig;
+            QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
             sslConfig.setPrivateKey(key);
             sslConfig.setLocalCertificate(certificate);
             sslConfig.setCaCertificates(caCertificates);


### PR DESCRIPTION
I got an `Invalid or empty cipher list ()` error when tried to connect to a webservice with PKCS12 certificate. 
This was due to the fact that the PKCS12 extracted  configuration was merged to an empty SSL configuration not to the default, which resulted loosing the available chipers.