### PR TITLE
Fix CMake warnings

### DIFF
--- a/KDSoapMacros.cmake
+++ b/KDSoapMacros.cmake
@@ -31,7 +31,10 @@ macro(KDSOAP_GENERATE_WSDL _sources)
       MAIN_DEPENDENCY ${_tmp_FILE} ${_header_wsdl_FILE}
       DEPENDS ${_tmp_FILE} ${KDWSDL2CPP})
 
-    set_source_files_properties(${_header_wsdl_FILE} ${_source_wsdl_FILE} PROPERTIES SKIP_AUTOMOC ON)
+    set_source_files_properties(${_header_wsdl_FILE} ${_source_wsdl_FILE} PROPERTIES
+        SKIP_AUTOMOC ON
+        SKIP_AUTOUIC ON
+    )
     qt5_wrap_cpp(_sources_MOCS ${_header_wsdl_FILE})
     list(APPEND ${_sources} ${_header_wsdl_FILE} ${_source_wsdl_FILE} ${_sources_MOCS})
   endforeach()


### PR DESCRIPTION
Set SKIP_AUTOUIC to ON for generated files by KDSoap CMake functions.
Just like it's being done in Qt5CoreMacros.cmake from qtbase as well.

Fixes:

```
CMake Warning (dev) in resources/sugarcrm/CMakeLists.txt:
  Policy CMP0071 is not set: Let AUTOMOC and AUTOUIC process GENERATED files.
  Run "cmake --help-policy CMP0071" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  For compatibility, CMake is excluding the GENERATED source file(s):

    ".../FatCRM/resources/sugarcrm/wsdl_sugar41.h"
    ".../FatCRM/resources/sugarcrm/wsdl_sugar41.cpp"
```