### PR TITLE
ignore CMake build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ configure.bat
 configure.sh
 .qmake.stash
 
+/build
+
 /include
 
 /examples/holidays_gui/qrc_resources.cpp


### PR DESCRIPTION
The directory is suggested here but not ignored by git..
https://github.com/KDAB/KDSoap/blob/dc4754f03aebb3201e61742c515df808f77471e6/INSTALL.txt#L19-L25