### PR TITLE
Export KDQName debug stream operator

### DIFF
--- a/src/KDSoapClient/KDQName.h
+++ b/src/KDSoapClient/KDQName.h
@@ -71,6 +71,6 @@ inline uint qHash(const KDQName &qn)
     return qHash(qn.nameSpace()) ^ qHash(qn.localName());
 }
 
-QDebug operator<<(QDebug dbg, const KDQName &qn);
+KDSOAP_EXPORT QDebug operator<<(QDebug dbg, const KDQName &qn);
 
 #endif


### PR DESCRIPTION
This is needed with Qt 6, if the operator is externally visible it is also assumed to be exported, causing linker errors in consumer code otherwise.

The alternative approach would be to remove the declaration from the header file entirely.