### PR TITLE
Fix compiler error C1061 when using more than 122 functions

### DIFF
--- a/kdwsdl2cpp/src/converter.h
+++ b/kdwsdl2cpp/src/converter.h
@@ -95,7 +95,7 @@ private:
 
     // Server Stub
     void convertServerService();
-    void generateServerMethod(KODE::Code &code, const Binding &binding, const Operation &operation, KODE::Class &newClass, bool first);
+    void generateServerMethod(KODE::Code &code, const Binding &binding, const Operation &operation, KODE::Class &newClass);
     void generateDelayedReponseMethod(const QString &methodName, const QString &retInputType, const Part &retPart, KODE::Class &newClass,
                                       const Binding &binding, const Message &outputMessage);
 


### PR DESCRIPTION
If the WSDL file contains more than 122 functions, the code generated by kdwsdl2cpp throws compiler error C1061 (MSVC). This is caused by the huge if statement in processRequest().

Fixed by replacing else if with if in processRequest().