### PR TITLE
Fix Qt5-Qt6 coinstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,11 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
         COMPATIBILITY
         AnyNewerVersion
     )
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kdsoap_version.h" DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient)
+    if(${PROJECT_NAME}_QT6)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kdsoap_version.h" DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient-Qt6/KDSoapClient)
+    else()
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kdsoap_version.h" DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient)
+    endif()
 
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/KDSoapConfig-buildtree.cmake.in"

--- a/docs/CHANGES_2_2.txt
+++ b/docs/CHANGES_2_2.txt
@@ -1,7 +1,8 @@
 
 General:
 ========
-*
+* buildsystem - Add co-installability of Qt5 and Qt6 headers back.
+  Installs Qt6 headers into their own subdirectory so client code still works, but can be co-installed with Qt5 again.
 
 Client-side:
 ============

--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -46,9 +46,14 @@ endif()
 target_link_libraries(
     kdsoap ${QT_LIBRARIES}
 )
+if(${PROJECT_NAME}_QT6)
+    set(client_INCLUDE_DIR ${INSTALL_INCLUDE_DIR}/KDSoapClient-Qt6)
+else()
+    set(client_INCLUDE_DIR ${INSTALL_INCLUDE_DIR})
+endif()
 target_include_directories(
     kdsoap
-    INTERFACE "$<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>"
+    INTERFACE "$<INSTALL_INTERFACE:${client_INCLUDE_DIR}>"
 )
 set_target_properties(kdsoap PROPERTIES SOVERSION ${${PROJECT_NAME}_SOVERSION} VERSION ${${PROJECT_NAME}_VERSION})
 
@@ -111,7 +116,7 @@ if(KDSoap_IS_ROOT_PROJECT)
               KDSoapEndpointReference.h
               KDQName.h
               KDSoapUdpClient.h
-        DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapClient
+        DESTINATION ${client_INCLUDE_DIR}/KDSoapClient
     )
 
     install(

--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -37,9 +37,14 @@ endif()
 target_link_libraries(
     kdsoap-server kdsoap ${QT_LIBRARIES}
 )
+if(${PROJECT_NAME}_QT6)
+    set(server_INCLUDE_DIR ${INSTALL_INCLUDE_DIR}/KDSoapServer-Qt6)
+else()
+    set(server_INCLUDE_DIR ${INSTALL_INCLUDE_DIR})
+endif()
 target_include_directories(
     kdsoap-server
-    INTERFACE "$<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>"
+    INTERFACE "$<INSTALL_INTERFACE:${server_INCLUDE_DIR}>"
 )
 set_target_properties(
     kdsoap-server PROPERTIES SOVERSION ${${PROJECT_NAME}_SOVERSION} VERSION ${${PROJECT_NAME}_VERSION}
@@ -88,7 +93,7 @@ if(KDSoap_IS_ROOT_PROJECT)
               KDSoapServerObjectInterface.h
               KDSoapServerGlobal.h
               KDSoapThreadPool.h
-        DESTINATION ${INSTALL_INCLUDE_DIR}/KDSoapServer
+        DESTINATION ${server_INCLUDE_DIR}/KDSoapServer
     )
 
     install(


### PR DESCRIPTION
Fixes #262.

This moves Qt6 headers to KDSoapX-qt6, similar to how the rest of the Qt6 library is installed. This also fixes kdwsdl2cpp to point to the correct header (so qt6 will generate includes for -qt6 and Qt5 is still the plain header name.)