### PR TITLE
Modify the copyright line to show the file creation year only

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: https://www.github.com/KDAB/KDSoap
 
 #misc source code
 Files: unittests/*/*.xsd unittests/*/*.wsdl unittests/*/*.XSD unittests/*/*.xml testtools/*.qrc examples/*/*.qrc examples/*/*.wsdl *.html *.css docs/manual/*.pdf *.bat *.pem
-Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #artwork
 Files: images/*.png docs/api/*.png docs/*.png docs/*.odg examples/*/*.mng examples/*/*.gif
-Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc documentation
 Files: *md *.txt *.html docs/manual/*.pdf
-Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc config files
 Files: .pre-commit-config.yaml .codespellrc .krazy .cmake-format.py .clang-format .clang-tidy .clazy .codedocs .gitignore .gitmodules .mdlrc .mdlrc.rb .pep8 .pylintrc appveyor.yml docs/api/Doxyfile.cmake distro/*
-Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 
 Files: kdwsdl2cpp/schemas/soapenc-1.1.xsd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-#
 # This file is part of the KD Soap project.
 #
 # SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>

--- a/FindKDSoap.cmake
+++ b/FindKDSoap.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/KDSoapConfig-buildtree.cmake.in
+++ b/KDSoapConfig-buildtree.cmake.in
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2013-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2013 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/KDSoapConfig.cmake.in
+++ b/KDSoapConfig.cmake.in
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/KDSoapMacros.cmake.in
+++ b/KDSoapMacros.cmake.in
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 License
 =======
-The KD Soap Software is Copyright 2010-2023 Klarälvdalens Datakonsult AB (KDAB),
+The KD Soap Software is Copyright 2010-2024 Klarälvdalens Datakonsult AB (KDAB),
 and is available under the terms of the MIT license.
 
 Note that this project requires the 3rd party 'libkode' submodule

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Thanks to our [contributors](CONTRIBUTORS.txt).
 
 ## License
 
-The KD Soap Software is Copyright 2010-2023, Klarälvdalens Datakonsult AB (KDAB),
+The KD Soap Software is Copyright 2010-2024, Klarälvdalens Datakonsult AB (KDAB),
 and is available under the terms of the [MIT](LICENSES/MIT.txt) license.
 
 Contact KDAB at <info@kdab.com> for any licensing queries.

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-22x22.png">
-      <font style="font-weight: bold;">&copy; 2010-2023 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; 2010-2024 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
 	    "The Qt, C++ and OpenGL Experts"<br>
 	    <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/bank_gui/CMakeLists.txt
+++ b/examples/bank_gui/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/bank_gui/bank_gui.cpp
+++ b/examples/bank_gui/bank_gui.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/bank_gui/mainwindow.cpp
+++ b/examples/bank_gui/mainwindow.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/bank_gui/mainwindow.h
+++ b/examples/bank_gui/mainwindow.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/bank_wsdl/CMakeLists.txt
+++ b/examples/bank_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/bank_wsdl/bank_wsdl.cpp
+++ b/examples/bank_wsdl/bank_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/helloworld_client/CMakeLists.txt
+++ b/examples/helloworld_client/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/helloworld_client/helloworld_client.h
+++ b/examples/helloworld_client/helloworld_client.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/helloworld_client/main.cpp
+++ b/examples/helloworld_client/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/helloworld_server/CMakeLists.txt
+++ b/examples/helloworld_server/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/helloworld_server/helloworld_serverobject.cpp
+++ b/examples/helloworld_server/helloworld_serverobject.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/helloworld_server/helloworld_serverobject.h
+++ b/examples/helloworld_server/helloworld_serverobject.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/examples/helloworld_server/main.cpp
+++ b/examples/helloworld_server/main.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/features/kdsoap.prf
+++ b/features/kdsoap.prf
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdsoap.pri
+++ b/kdsoap.pri
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdwsdl2cpp.pri
+++ b/kdwsdl2cpp.pri
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdwsdl2cpp/CMakeLists.txt
+++ b/kdwsdl2cpp/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/kdwsdl2cpp/kode_export.h
+++ b/kdwsdl2cpp/kode_export.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/scripts/genignore.py
+++ b/scripts/genignore.py
@@ -5,7 +5,7 @@ import stat
 #
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDSoapClient/KDDateTime.cpp
+++ b/src/KDSoapClient/KDDateTime.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDDateTime.h
+++ b/src/KDSoapClient/KDDateTime.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoap.h
+++ b/src/KDSoapClient/KDSoap.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapAuthentication.cpp
+++ b/src/KDSoapClient/KDSoapAuthentication.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapAuthentication.h
+++ b/src/KDSoapClient/KDSoapAuthentication.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapClientInterface.cpp
+++ b/src/KDSoapClient/KDSoapClientInterface.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapClientInterface.h
+++ b/src/KDSoapClient/KDSoapClientInterface.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapClientInterface_p.h
+++ b/src/KDSoapClient/KDSoapClientInterface_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapClientThread.cpp
+++ b/src/KDSoapClient/KDSoapClientThread.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapClientThread_p.h
+++ b/src/KDSoapClient/KDSoapClientThread_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapEndpointReference.cpp
+++ b/src/KDSoapClient/KDSoapEndpointReference.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapEndpointReference.h
+++ b/src/KDSoapClient/KDSoapEndpointReference.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapFaultException.cpp
+++ b/src/KDSoapClient/KDSoapFaultException.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapFaultException.h
+++ b/src/KDSoapClient/KDSoapFaultException.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapGlobal.h
+++ b/src/KDSoapClient/KDSoapGlobal.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapJob.cpp
+++ b/src/KDSoapClient/KDSoapJob.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapJob.h
+++ b/src/KDSoapClient/KDSoapJob.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessage.cpp
+++ b/src/KDSoapClient/KDSoapMessage.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessage.h
+++ b/src/KDSoapClient/KDSoapMessage.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.h
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageReader.cpp
+++ b/src/KDSoapClient/KDSoapMessageReader.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageReader_p.h
+++ b/src/KDSoapClient/KDSoapMessageReader_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageWriter.cpp
+++ b/src/KDSoapClient/KDSoapMessageWriter.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapMessageWriter_p.h
+++ b/src/KDSoapClient/KDSoapMessageWriter_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapNamespaceManager.cpp
+++ b/src/KDSoapClient/KDSoapNamespaceManager.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapNamespaceManager.h
+++ b/src/KDSoapClient/KDSoapNamespaceManager.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
+++ b/src/KDSoapClient/KDSoapNamespacePrefixes_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCall.cpp
+++ b/src/KDSoapClient/KDSoapPendingCall.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCall.h
+++ b/src/KDSoapClient/KDSoapPendingCall.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCallWatcher.cpp
+++ b/src/KDSoapClient/KDSoapPendingCallWatcher.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCallWatcher.h
+++ b/src/KDSoapClient/KDSoapPendingCallWatcher.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCallWatcher_p.h
+++ b/src/KDSoapClient/KDSoapPendingCallWatcher_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapPendingCall_p.h
+++ b/src/KDSoapClient/KDSoapPendingCall_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapReplySslHandler.cpp
+++ b/src/KDSoapClient/KDSoapReplySslHandler.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapReplySslHandler_p.h
+++ b/src/KDSoapClient/KDSoapReplySslHandler_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapSslHandler.cpp
+++ b/src/KDSoapClient/KDSoapSslHandler.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapSslHandler.h
+++ b/src/KDSoapClient/KDSoapSslHandler.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapUdpClient.cpp
+++ b/src/KDSoapClient/KDSoapUdpClient.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapUdpClient.h
+++ b/src/KDSoapClient/KDSoapUdpClient.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapUdpClient_p.h
+++ b/src/KDSoapClient/KDSoapUdpClient_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/KDSoapValue.h
+++ b/src/KDSoapClient/KDSoapValue.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapClient/doxygen.cpp
+++ b/src/KDSoapClient/doxygen.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2011-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2011 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDSoapServer/KDSoapDelayedResponseHandle.cpp
+++ b/src/KDSoapServer/KDSoapDelayedResponseHandle.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapDelayedResponseHandle.h
+++ b/src/KDSoapServer/KDSoapDelayedResponseHandle.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServer.cpp
+++ b/src/KDSoapServer/KDSoapServer.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServer.h
+++ b/src/KDSoapServer/KDSoapServer.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerAuthInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerAuthInterface.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerAuthInterface.h
+++ b/src/KDSoapServer/KDSoapServerAuthInterface.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.h
+++ b/src/KDSoapServer/KDSoapServerCustomVerbRequestInterface.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerGlobal.h
+++ b/src/KDSoapServer/KDSoapServerGlobal.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerObjectInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerObjectInterface.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerObjectInterface.h
+++ b/src/KDSoapServer/KDSoapServerObjectInterface.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerRawXMLInterface.cpp
+++ b/src/KDSoapServer/KDSoapServerRawXMLInterface.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerRawXMLInterface.h
+++ b/src/KDSoapServer/KDSoapServerRawXMLInterface.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerSocket.cpp
+++ b/src/KDSoapServer/KDSoapServerSocket.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerSocket_p.h
+++ b/src/KDSoapServer/KDSoapServerSocket_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerThread.cpp
+++ b/src/KDSoapServer/KDSoapServerThread.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapServerThread_p.h
+++ b/src/KDSoapServer/KDSoapServerThread_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapSocketList.cpp
+++ b/src/KDSoapServer/KDSoapSocketList.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapSocketList_p.h
+++ b/src/KDSoapServer/KDSoapSocketList_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapThreadPool.cpp
+++ b/src/KDSoapServer/KDSoapThreadPool.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/src/KDSoapServer/KDSoapThreadPool.h
+++ b/src/KDSoapServer/KDSoapThreadPool.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/testtools/CMakeLists.txt
+++ b/testtools/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/testtools/httpserver_p.cpp
+++ b/testtools/httpserver_p.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/testtools/httpserver_p.h
+++ b/testtools/httpserver_p.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/QSharedPointer_include/CMakeLists.txt
+++ b/unittests/QSharedPointer_include/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/QSharedPointer_include/test_qsharedpointer_include.cpp
+++ b/unittests/QSharedPointer_include/test_qsharedpointer_include.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/add_test_subdir.sh
+++ b/unittests/add_test_subdir.sh
@@ -2,7 +2,7 @@
 #
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/basic/CMakeLists.txt
+++ b/unittests/basic/CMakeLists.txt
@@ -1,11 +1,10 @@
-project(basic)
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #
 
+project(basic)
 set(basic_SRCS test_basic.cpp)
 add_unittest(${basic_SRCS})

--- a/unittests/basic/test_basic.cpp
+++ b/unittests/basic/test_basic.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/builtinhttp/CMakeLists.txt
+++ b/unittests/builtinhttp/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/builtinhttp/test_builtinhttp.cpp
+++ b/unittests/builtinhttp/test_builtinhttp.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/clearbooks/CMakeLists.txt
+++ b/unittests/clearbooks/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/clearbooks/test_clearbooks.cpp
+++ b/unittests/clearbooks/test_clearbooks.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/cribis/CMakeLists.txt
+++ b/unittests/cribis/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/cribis/test_cribis.cpp
+++ b/unittests/cribis/test_cribis.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/date_example/CMakeLists.txt
+++ b/unittests/date_example/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/date_example/test_date_example.cpp
+++ b/unittests/date_example/test_date_example.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/default_attribute_value_wsdl/CMakeLists.txt
+++ b/unittests/default_attribute_value_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/default_attribute_value_wsdl/test_default_attribute_value_wsdl.cpp
+++ b/unittests/default_attribute_value_wsdl/test_default_attribute_value_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/dv_terminalauth/CMakeLists.txt
+++ b/unittests/dv_terminalauth/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/dv_terminalauth/test_dv_terminalauth.cpp
+++ b/unittests/dv_terminalauth/test_dv_terminalauth.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/dwservice_12_wsdl/CMakeLists.txt
+++ b/unittests/dwservice_12_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/dwservice_12_wsdl/test_dwservice_12_wsdl.cpp
+++ b/unittests/dwservice_12_wsdl/test_dwservice_12_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/dwservice_combined_wsdl/CMakeLists.txt
+++ b/unittests/dwservice_combined_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/dwservice_combined_wsdl/test_dwservice_combined_wsdl.cpp
+++ b/unittests/dwservice_combined_wsdl/test_dwservice_combined_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/dwservice_wsdl/CMakeLists.txt
+++ b/unittests/dwservice_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/dwservice_wsdl/test_dwservice_wsdl.cpp
+++ b/unittests/dwservice_wsdl/test_dwservice_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/element_ns_wsdl/CMakeLists.txt
+++ b/unittests/element_ns_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/element_ns_wsdl/test_element_ns_wsdl.cpp
+++ b/unittests/element_ns_wsdl/test_element_ns_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/element_ns_wsdl/test_element_ns_wsdl.h
+++ b/unittests/element_ns_wsdl/test_element_ns_wsdl.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/empty_element_wsdl/CMakeLists.txt
+++ b/unittests/empty_element_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/empty_element_wsdl/test_empty_element_wsdl.cpp
+++ b/unittests/empty_element_wsdl/test_empty_element_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/empty_list_wsdl/CMakeLists.txt
+++ b/unittests/empty_list_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/empty_list_wsdl/test_empty_list_wsdl.cpp
+++ b/unittests/empty_list_wsdl/test_empty_list_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/empty_response_wsdl/CMakeLists.txt
+++ b/unittests/empty_response_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/empty_response_wsdl/test_issue1.cpp
+++ b/unittests/empty_response_wsdl/test_issue1.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/encapsecurity/CMakeLists.txt
+++ b/unittests/encapsecurity/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/encapsecurity/test_encapsecurity.cpp
+++ b/unittests/encapsecurity/test_encapsecurity.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/enum_escape/CMakeLists.txt
+++ b/unittests/enum_escape/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/enum_escape/test_enum.cpp
+++ b/unittests/enum_escape/test_enum.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/enum_with_length_restriction/CMakeLists.txt
+++ b/unittests/enum_with_length_restriction/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/enum_with_length_restriction/test_enum.cpp
+++ b/unittests/enum_with_length_restriction/test_enum.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/enum_with_length_restriction/test_enum_length_restriction.cpp
+++ b/unittests/enum_with_length_restriction/test_enum_length_restriction.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/enzo/CMakeLists.txt
+++ b/unittests/enzo/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/enzo/test_enzo.cpp
+++ b/unittests/enzo/test_enzo.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/fault_namespace/CMakeLists.txt
+++ b/unittests/fault_namespace/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/fault_namespace/test_fault_namespace.cpp
+++ b/unittests/fault_namespace/test_fault_namespace.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/groupwise_wsdl/CMakeLists.txt
+++ b/unittests/groupwise_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/groupwise_wsdl/test_groupwise_wsdl.cpp
+++ b/unittests/groupwise_wsdl/test_groupwise_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/ihc_wsdl/CMakeLists.txt
+++ b/unittests/ihc_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ihc_wsdl/test_ihc.cpp
+++ b/unittests/ihc_wsdl/test_ihc.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/import_definition/CMakeLists.txt
+++ b/unittests/import_definition/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/import_definition/test_import_definition.cpp
+++ b/unittests/import_definition/test_import_definition.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/kddatetime/CMakeLists.txt
+++ b/unittests/kddatetime/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/kddatetime/test_kddatetime.cpp
+++ b/unittests/kddatetime/test_kddatetime.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/keep_unused_types/CMakeLists.txt
+++ b/unittests/keep_unused_types/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/keep_unused_types/keep_unused_types.cpp
+++ b/unittests/keep_unused_types/keep_unused_types.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/literal_true_false/CMakeLists.txt
+++ b/unittests/literal_true_false/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/literal_true_false/test_literal.cpp
+++ b/unittests/literal_true_false/test_literal.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/logbook_wsdl/CMakeLists.txt
+++ b/unittests/logbook_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/logbook_wsdl/test_logbook_wsdl.cpp
+++ b/unittests/logbook_wsdl/test_logbook_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/messagereader/CMakeLists.txt
+++ b/unittests/messagereader/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/messagereader/test_messagereader.cpp
+++ b/unittests/messagereader/test_messagereader.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/msexchange_noservice_wsdl/CMakeLists.txt
+++ b/unittests/msexchange_noservice_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/msexchange_noservice_wsdl/test_msexchange_noservice_wsdl.cpp
+++ b/unittests/msexchange_noservice_wsdl/test_msexchange_noservice_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/msexchange_wsdl/CMakeLists.txt
+++ b/unittests/msexchange_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/msexchange_wsdl/test_msexchange_wsdl.cpp
+++ b/unittests/msexchange_wsdl/test_msexchange_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/multiple_input_param/CMakeLists.txt
+++ b/unittests/multiple_input_param/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/multiple_input_param/test_multiple_input_param.cpp
+++ b/unittests/multiple_input_param/test_multiple_input_param.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_boost_optional/CMakeLists.txt
+++ b/unittests/optionaltype_boost_optional/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/optionaltype_boost_optional/test_boostapi.cpp
+++ b/unittests/optionaltype_boost_optional/test_boostapi.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_boost_optional/test_boostapi.h
+++ b/unittests/optionaltype_boost_optional/test_boostapi.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_pointer/CMakeLists.txt
+++ b/unittests/optionaltype_pointer/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/optionaltype_pointer/test_optionaltype_pointer.cpp
+++ b/unittests/optionaltype_pointer/test_optionaltype_pointer.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_pointer/test_optionaltype_pointer.h
+++ b/unittests/optionaltype_pointer/test_optionaltype_pointer.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_regular/CMakeLists.txt
+++ b/unittests/optionaltype_regular/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/optionaltype_regular/test_optionaltype_regular.cpp
+++ b/unittests/optionaltype_regular/test_optionaltype_regular.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/optionaltype_regular/test_optionaltype_regular.h
+++ b/unittests/optionaltype_regular/test_optionaltype_regular.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/pki.pca.dfn.de/CMakeLists.txt
+++ b/unittests/pki.pca.dfn.de/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/pki.pca.dfn.de/test_pki.cpp
+++ b/unittests/pki.pca.dfn.de/test_pki.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/prefix_wsdl/CMakeLists.txt
+++ b/unittests/prefix_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/prefix_wsdl/test_prefix.cpp
+++ b/unittests/prefix_wsdl/test_prefix.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/salesforce_wsdl/CMakeLists.txt
+++ b/unittests/salesforce_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/salesforce_wsdl/test_salesforce_wsdl.cpp
+++ b/unittests/salesforce_wsdl/test_salesforce_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/serverlib/CMakeLists.txt
+++ b/unittests/serverlib/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/serverlib/test_serverlib.cpp
+++ b/unittests/serverlib/test_serverlib.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/soap12/CMakeLists.txt
+++ b/unittests/soap12/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/soap12/test_soap12.cpp
+++ b/unittests/soap12/test_soap12.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/soap_over_udp/CMakeLists.txt
+++ b/unittests/soap_over_udp/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/soap_over_udp/test_soap_over_udp.cpp
+++ b/unittests/soap_over_udp/test_soap_over_udp.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/specialchars_wsdl/CMakeLists.txt
+++ b/unittests/specialchars_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/specialchars_wsdl/test_specialchars_wsdl.cpp
+++ b/unittests/specialchars_wsdl/test_specialchars_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/sugar_wsdl/CMakeLists.txt
+++ b/unittests/sugar_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/sugar_wsdl/test_sugar_wsdl.cpp
+++ b/unittests/sugar_wsdl/test_sugar_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/tech3356_wsdl/CMakeLists.txt
+++ b/unittests/tech3356_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/tech3356_wsdl/test_tech3356.cpp
+++ b/unittests/tech3356_wsdl/test_tech3356.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/test_calc/CMakeLists.txt
+++ b/unittests/test_calc/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/test_calc/test_calc.cpp
+++ b/unittests/test_calc/test_calc.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/uitapi/CMakeLists.txt
+++ b/unittests/uitapi/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/uitapi/test_uitapi.cpp
+++ b/unittests/uitapi/test_uitapi.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/unqualified_formdefault/CMakeLists.txt
+++ b/unittests/unqualified_formdefault/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/unqualified_formdefault/test_unqualified.cpp
+++ b/unittests/unqualified_formdefault/test_unqualified.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/vidyo/CMakeLists.txt
+++ b/unittests/vidyo/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/vidyo/test_vidyo.cpp
+++ b/unittests/vidyo/test_vidyo.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/webcalls/CMakeLists.txt
+++ b/unittests/webcalls/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/webcalls/test_webcalls.cpp
+++ b/unittests/webcalls/test_webcalls.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/webcalls_wsdl/CMakeLists.txt
+++ b/unittests/webcalls_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/webcalls_wsdl/test_webcalls_wsdl.cpp
+++ b/unittests/webcalls_wsdl/test_webcalls_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/ws_addressing_support/CMakeLists.txt
+++ b/unittests/ws_addressing_support/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ws_addressing_support/test_wsaddressing.cpp
+++ b/unittests/ws_addressing_support/test_wsaddressing.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/ws_discovery_wsdl/CMakeLists.txt
+++ b/unittests/ws_discovery_wsdl/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
+++ b/unittests/ws_discovery_wsdl/test_ws_discovery_wsdl.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/ws_usernametoken_support/CMakeLists.txt
+++ b/unittests/ws_usernametoken_support/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
+++ b/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/wsdl_document/CMakeLists.txt
+++ b/unittests/wsdl_document/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/wsdl_document/test_wsdl_document.cpp
+++ b/unittests/wsdl_document/test_wsdl_document.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/wsdl_rpc-server/CMakeLists.txt
+++ b/unittests/wsdl_rpc-server/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/wsdl_rpc-server/test_wsdl_rpc_server.cpp
+++ b/unittests/wsdl_rpc-server/test_wsdl_rpc_server.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **

--- a/unittests/wsdl_rpc/CMakeLists.txt
+++ b/unittests/wsdl_rpc/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KD Soap project.
 #
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/unittests/wsdl_rpc/test_wsdl_rpc.cpp
+++ b/unittests/wsdl_rpc/test_wsdl_rpc.cpp
@@ -2,7 +2,7 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 **
 ** SPDX-License-Identifier: MIT
 **


### PR DESCRIPTION
Per KDAB policy:
No longer show the year range of creationYear-currentYear. The creationYear is  enough.

update the entire project copyright to say 2024

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code