### PR TITLE
Install the Windows pdb files in the bin dir

### DIFF
--- a/src/KDSoapClient/CMakeLists.txt
+++ b/src/KDSoapClient/CMakeLists.txt
@@ -129,7 +129,7 @@ if(KDSoap_IS_ROOT_PROJECT)
     if(MSVC AND NOT ${PROJECT_NAME}_STATIC)
         install(
             FILES "$<TARGET_PDB_FILE_DIR:kdsoap>/$<TARGET_PDB_FILE_NAME:kdsoap>"
-            DESTINATION ${INSTALL_LIBRARY_DIR}
+            DESTINATION ${INSTALL_RUNTIME_DIR}
             CONFIGURATIONS Debug RelWithDebInfo
         )
     endif()

--- a/src/KDSoapServer/CMakeLists.txt
+++ b/src/KDSoapServer/CMakeLists.txt
@@ -106,7 +106,7 @@ if(KDSoap_IS_ROOT_PROJECT)
     if(MSVC AND NOT ${PROJECT_NAME}_STATIC)
         install(
             FILES "$<TARGET_PDB_FILE_DIR:kdsoap-server>/$<TARGET_PDB_FILE_NAME:kdsoap-server>"
-            DESTINATION ${INSTALL_LIBRARY_DIR}
+            DESTINATION ${INSTALL_RUNTIME_DIR}
             CONFIGURATIONS Debug RelWithDebInfo
         )
     endif()


### PR DESCRIPTION
Install the Windows pdb files in the bin (or runtime) directory and not into the library dir.