### PR TITLE
CI update to macOS 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macos-12
+          - macos-13
 
         build_type:
           - Debug


### PR DESCRIPTION
macOS 12 is deprecated and will soon be removed