### PR TITLE
Don't set clazy settings in multiple places

### DIFF
--- a/.clazy
+++ b/.clazy
@@ -1,7 +1,0 @@
-#do not report clazy results for these subdirs
-#libkode is a separate project that we care about
-SKIP /libkode/
-
-#clazy checks specification
-#currently there are more than 1000 qstring-allocation issues
-CHECKS level2,no-qstring-allocations,no-fully-qualified-moc-types

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,11 +6,7 @@ name: CI Nightly
 
 on:
   schedule:
-  - cron: '0 3 * * *'
-
-env:
-  CLAZY_CHECKS: "level2,no-qstring-allocations,no-fully-qualified-moc-types"
-  CLAZY_IGNORE_DIRS: ".*libkode.*"
+    - cron: "0 3 * * *"
 
 jobs:
   build:
@@ -23,11 +19,14 @@ jobs:
 
         config:
           - name: clang-tidy
-            cmake_arg: '-DCMAKE_CXX_CLANG_TIDY=clang-tidy'
+            # To be moved to a cmake preset
+            cmake_arg: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy -B ./build -G Ninja --warn-uninitialized -Werror=dev -DCMAKE_BUILD_TYPE=Debug -DKDSoap_QT6=ON -DKDSoap_TESTS=ON"
+            cmake_build_arg: "./build"
             qt_version: "6.6"
 
           - name: clazy
-            cmake_arg: '-DCMAKE_CXX_COMPILER=clazy'
+            cmake_arg: "--preset=clazy"
+            cmake_build_arg: "--preset=clazy"
             qt_version: "6.6"
             apt_pgks:
               - clazy
@@ -50,20 +49,14 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: 'master' # schedule.cron do not allow branch setting
+          ref: "master" # schedule.cron do not allow branch setting
 
       - name: Fetch Git submodules
         run: git submodule update --init --recursive
 
       - name: Configure project
         run: >
-          cmake -S . -B ./build -G Ninja ${{ matrix.config.cmake_arg }}
-          -DCMAKE_BUILD_TYPE=Release
-          --warn-uninitialized -Werror=dev
-          -DCMAKE_BUILD_TYPE=Debug
-          -DKDSoap_QT6=ON
-          -DKDSoap_TESTS=ON
+          cmake -S . ${{ matrix.config.cmake_arg }}
 
       - name: Build Project
-        id: ctest
-        run: cmake --build ./build
+        run: cmake --build ${{ matrix.config.cmake_build_arg }}

--- a/.github/workflows/tidyclazy.yml
+++ b/.github/workflows/tidyclazy.yml
@@ -27,14 +27,11 @@ jobs:
 
         config:
           - name: clang-tidy
-            # To be moved to a cmake preset
-            cmake_arg: "-DCMAKE_CXX_CLANG_TIDY=clang-tidy -B ./build -G Ninja --warn-uninitialized -Werror=dev -DCMAKE_BUILD_TYPE=Debug -DKDSoap_QT6=ON -DKDSoap_TESTS=ON"
-            cmake_build_arg: "./build"
+            preset: "clang-tidy"
             qt_version: "6.6"
 
           - name: clazy
-            cmake_arg: "--preset=clazy"
-            cmake_build_arg: "--preset=clazy"
+            preset: "clazy"
             qt_version: "6.6"
             apt_pgks:
               - clazy
@@ -63,7 +60,7 @@ jobs:
 
       - name: Configure project
         run: >
-          cmake -S . ${{ matrix.config.cmake_arg }}
+          cmake --preset=${{ matrix.config.preset }}
 
       - name: Build Project
-        run: cmake --build ${{ matrix.config.cmake_build_arg }}
+        run: cmake --build --preset=${{ matrix.config.preset }}

--- a/.github/workflows/tidyclazy.yml
+++ b/.github/workflows/tidyclazy.yml
@@ -2,11 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: CI Nightly
+name: Tidy and Clazy
 
 on:
-  schedule:
-    - cron: "0 3 * * *"
+  push:
+    branches:
+      - master
+      - kdsoap-2.1
+      - kdsoap-2.2
+  pull_request:
+    branches:
+      - master
+      - kdsoap-2.1
+      - kdsoap-2.2
 
 jobs:
   build:
@@ -47,9 +55,8 @@ jobs:
           sudo apt update -qq
           echo ${{ join(matrix.config.apt_pgks, ' ') }} | xargs sudo apt install -y
 
-      - uses: actions/checkout@v4
-        with:
-          ref: "master" # schedule.cron do not allow branch setting
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
       - name: Fetch Git submodules
         run: git submodule update --init --recursive

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,6 +63,15 @@
       }
     },
     {
+      "name": "clang-tidy",
+      "inherits": "dev",
+      "cacheVariables": {
+        "KDSoap_EXAMPLES": "OFF",
+        "KDSoap_TESTS": "OFF",
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy"
+      }
+    },
+    {
       "name": "release",
       "inherits": "base",
       "cacheVariables": {
@@ -86,6 +95,10 @@
         "CCACHE_DISABLE": "ON",
         "CLAZY_IGNORE_DIRS": ".*libkode.*"
       }
+    },
+    {
+      "name": "clang-tidy",
+      "configurePreset": "clang-tidy"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -82,8 +82,9 @@
       "name": "clazy",
       "configurePreset": "clazy",
       "environment": {
-        "CLAZY_CHECKS": "level2,detaching-member,heap-allocated-small-trivial-type,isempty-vs-count,qstring-varargs,qvariant-template-instantiation,raw-environment-function,reserve-candidates,signal-with-return-value,thread-with-slots,no-ctor-missing-parent-argument,no-missing-typeinfo,no-skipped-base-method",
-        "CCACHE_DISABLE": "ON"
+        "CLAZY_CHECKS": "level2,no-qstring-allocations,no-fully-qualified-moc-types",
+        "CCACHE_DISABLE": "ON",
+        "CLAZY_IGNORE_DIRS": ".*libkode.*"
       }
     }
   ]


### PR DESCRIPTION
Removed .clazy file which was only read by KDAB CI. Moved env variables from nightly.yml to CMakePresets.json, so users can run clazy locally as well.
Adapted nightly.yml to use the preset.

Also 2 whitespace changes which I only noticed now, done by editor on save.