### PR TITLE
Create jobs for soap one way operations with kdwsdl2cpp

### DIFF
--- a/kdwsdl2cpp/src/compiler.cpp
+++ b/kdwsdl2cpp/src/compiler.cpp
@@ -47,14 +47,22 @@ void Compiler::download()
         }
 
         // qDebug() << "parsing" << fileName;
+        QDomDocument doc;
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         QString errorMsg;
         int errorLine, errorCol;
-        QDomDocument doc;
         if (!doc.setContent(&file, false, &errorMsg, &errorLine, &errorCol)) {
             qDebug("%s at (%d,%d)", qPrintable(errorMsg), errorLine, errorCol);
             QCoreApplication::exit(2);
             return;
         }
+#else
+        if (auto result = doc.setContent(&file); !result) {
+            qDebug("%s at (%lld,%lld)", qPrintable(result.errorMessage), result.errorLine, result.errorColumn);
+            QCoreApplication::exit(2);
+            return;
+        }
+#endif
 
         parse(doc.documentElement());
 

--- a/kdwsdl2cpp/src/converter_clientstub.cpp
+++ b/kdwsdl2cpp/src/converter_clientstub.cpp
@@ -376,7 +376,7 @@ bool Converter::convertClientService()
                 // for each operation, create a job class
                 for (const Operation &operation : std::as_const(operations)) {
                     Operation::OperationType opType = operation.operationType();
-                    if (opType != Operation::SolicitResponseOperation && opType != Operation::RequestResponseOperation) {
+                    if (opType == Operation::NotificationOperation) {
                         continue;
                     }
 

--- a/kdwsdl2cpp/wsdl/definitions.cpp
+++ b/kdwsdl2cpp/wsdl/definitions.cpp
@@ -246,6 +246,7 @@ void Definitions::importDefinition(ParserContext *context, const QString &locati
         }
 
         QDomDocument doc(QLatin1String("kwsdl"));
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         QString errorMsg;
         int errorLine, errorColumn;
         bool ok = doc.setContent(&file, false, &errorMsg, &errorLine, &errorColumn);
@@ -253,6 +254,12 @@ void Definitions::importDefinition(ParserContext *context, const QString &locati
             qDebug("Error[%d:%d] %s", errorLine, errorColumn, qPrintable(errorMsg));
             return;
         }
+#else
+        if (auto result = doc.setContent(&file); !result) {
+            qDebug("Error[%lld:%lld] %s", result.errorLine, result.errorColumn, qPrintable(result.errorMessage));
+            return;
+        }
+#endif
 
         // prepare the new context to avoid infinite recursion
         QDomElement rootNode = doc.documentElement();

--- a/src/KDSoapClient/KDDateTime.cpp
+++ b/src/KDSoapClient/KDDateTime.cpp
@@ -10,6 +10,9 @@
 #include "KDDateTime.h"
 #include <QDebug>
 #include <QSharedData>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#include <QTimeZone>
+#endif
 
 class KDDateTimeData : public QSharedData
 {
@@ -64,11 +67,21 @@ void KDDateTime::setTimeZone(const QString &timeZone)
     // Just in case someone cares: set the time spec in QDateTime accordingly.
     // We can't do this the other way round, there's no public API for the offset-from-utc case.
     if (timeZone == QLatin1String("Z")) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         setTimeSpec(Qt::UTC);
+#else
+        QDateTime::setTimeZone(QTimeZone(QTimeZone::UTC));
+#endif
     } else if (timeZone.isEmpty()) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         setTimeSpec(Qt::LocalTime);
+#else
+        QDateTime::setTimeZone(QTimeZone(QTimeZone::LocalTime));
+#endif
     } else {
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         setTimeSpec(Qt::OffsetFromUTC);
+#endif
         const int pos = timeZone.indexOf(QLatin1Char(':'));
         if (pos > 0) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -80,7 +93,11 @@ void KDDateTime::setTimeZone(const QString &timeZone)
             const int minutes = timeZoneView.sliced(pos + 1).toInt();
 #endif
             const int offset = hours * 3600 + minutes * 60;
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
             setOffsetFromUtc(offset);
+#else
+            QDateTime::setTimeZone(QTimeZone::fromSecondsAheadOfUtc(offset));
+#endif
         }
     }
 }

--- a/src/KDSoapClient/KDDateTime.cpp
+++ b/src/KDSoapClient/KDDateTime.cpp
@@ -92,7 +92,7 @@ void KDDateTime::setTimeZone(const QString &timeZone)
             const int hours = timeZoneView.first(pos).toInt();
             const int minutes = timeZoneView.sliced(pos + 1).toInt();
 #endif
-            const int offset = hours * 3600 + minutes * 60;
+            const int offset = hours * 3600 + (hours >= 0 ? minutes : -minutes) * 60;
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
             setOffsetFromUtc(offset);
 #else

--- a/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
+++ b/src/KDSoapClient/KDSoapMessageAddressingProperties.cpp
@@ -278,7 +278,11 @@ static void writeAddressField(QXmlStreamWriter &writer, const QString &addressin
 static void writeKDSoapValueVariant(QXmlStreamWriter &writer, const KDSoapValue &value)
 {
     const QVariant valueToWrite = value.value();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     if (valueToWrite.canConvert(QVariant::String)) {
+#else
+    if (valueToWrite.canConvert(QMetaType(QMetaType::QString))) {
+#endif
         writer.writeCharacters(valueToWrite.toString());
     } else {
         qWarning("Warning: KDSoapMessageAddressingProperties call to writeKDSoapValueVariant could not write the given KDSoapValue "

--- a/src/KDSoapClient/KDSoapMessageReader.cpp
+++ b/src/KDSoapClient/KDSoapMessageReader.cpp
@@ -37,15 +37,15 @@ static int xmlTypeToMetaType(const QString &xmlType)
     {
         const char *xml; // xsd: prefix assumed
         const int metaTypeId;
-    } s_types[] = {{"string", QVariant::String}, // or QUrl
-                   {"base64Binary", QVariant::ByteArray},
-                   {"int", QVariant::Int}, // or long, or uint, or longlong
-                   {"unsignedInt", QVariant::ULongLong},
-                   {"boolean", QVariant::Bool},
+    } s_types[] = {{"string", QMetaType::QString}, // or QUrl
+                   {"base64Binary", QMetaType::QByteArray},
+                   {"int", QMetaType::Int}, // or long, or uint, or longlong
+                   {"unsignedInt", QMetaType::ULongLong},
+                   {"boolean", QMetaType::Bool},
                    {"float", QMetaType::Float},
-                   {"double", QVariant::Double},
-                   {"time", QVariant::Time},
-                   {"date", QVariant::Date}};
+                   {"double", QMetaType::Double},
+                   {"time", QMetaType::QTime},
+                   {"date", QMetaType::QDate}};
     // Speed: could be sorted and then we could use qBinaryFind
     for (const auto &type : s_types) {
         if (xmlType == QLatin1String(type.xml)) {

--- a/src/KDSoapClient/KDSoapValue.cpp
+++ b/src/KDSoapClient/KDSoapValue.cpp
@@ -165,14 +165,14 @@ bool KDSoapValue::operator!=(const KDSoapValue &other) const
 static QString variantToTextValue(const QVariant &value, const QString &typeNs, const QString &type)
 {
     switch (value.userType()) {
-    case QVariant::Char:
+    case QMetaType::QChar:
     // fall-through
-    case QVariant::String:
+    case QMetaType::QString:
         return value.toString();
-    case QVariant::Url:
+    case QMetaType::QUrl:
         // xmlpatterns/data/qatomicvalue.cpp says to do this:
         return value.toUrl().toString();
-    case QVariant::ByteArray: {
+    case QMetaType::QByteArray: {
         const QByteArray data = value.toByteArray();
         if (typeNs == KDSoapNamespaceManager::xmlSchema1999() || typeNs == KDSoapNamespaceManager::xmlSchema2001()) {
             if (type == QLatin1String("hexBinary")) {
@@ -184,19 +184,19 @@ static QString variantToTextValue(const QVariant &value, const QString &typeNs, 
         const QByteArray b64 = value.toByteArray().toBase64();
         return QString::fromLatin1(b64.constData(), b64.size());
     }
-    case QVariant::Int:
+    case QMetaType::Int:
     // fall-through
-    case QVariant::LongLong:
+    case QMetaType::LongLong:
     // fall-through
-    case QVariant::UInt:
+    case QMetaType::UInt:
         return QString::number(value.toLongLong());
-    case QVariant::ULongLong:
+    case QMetaType::ULongLong:
         return QString::number(value.toULongLong());
-    case QVariant::Bool:
+    case QMetaType::Bool:
     case QMetaType::Float:
-    case QVariant::Double:
+    case QMetaType::Double:
         return value.toString();
-    case QVariant::Time: {
+    case QMetaType::QTime: {
         const QTime time = value.toTime();
         if (time.msec()) {
             // include milli-seconds
@@ -205,11 +205,11 @@ static QString variantToTextValue(const QVariant &value, const QString &typeNs, 
             return time.toString(Qt::ISODate);
         }
     }
-    case QVariant::Date:
+    case QMetaType::QDate:
         return value.toDate().toString(Qt::ISODate);
-    case QVariant::DateTime: // https://www.w3.org/TR/xmlschema-2/#dateTime
+    case QMetaType::QDateTime: // https://www.w3.org/TR/xmlschema-2/#dateTime
         return KDDateTime(value.toDateTime()).toDateString();
-    case QVariant::Invalid:
+    case QMetaType::UnknownType:
         qDebug() << "ERROR: Got invalid QVariant in a KDSoapValue";
         return QString();
     default:
@@ -232,33 +232,33 @@ static QString variantToTextValue(const QVariant &value, const QString &typeNs, 
 static QString variantToXMLType(const QVariant &value)
 {
     switch (value.userType()) {
-    case QVariant::Char:
+    case QMetaType::QChar:
     // fall-through
-    case QVariant::String:
+    case QMetaType::QString:
     // fall-through
-    case QVariant::Url:
+    case QMetaType::QUrl:
         return QLatin1String("xsd:string");
-    case QVariant::ByteArray:
+    case QMetaType::QByteArray:
         return QLatin1String("xsd:base64Binary");
-    case QVariant::Int:
+    case QMetaType::Int:
     // fall-through
-    case QVariant::LongLong:
+    case QMetaType::LongLong:
     // fall-through
-    case QVariant::UInt:
+    case QMetaType::UInt:
         return QLatin1String("xsd:int");
-    case QVariant::ULongLong:
+    case QMetaType::ULongLong:
         return QLatin1String("xsd:unsignedInt");
-    case QVariant::Bool:
+    case QMetaType::Bool:
         return QLatin1String("xsd:boolean");
     case QMetaType::Float:
         return QLatin1String("xsd:float");
-    case QVariant::Double:
+    case QMetaType::Double:
         return QLatin1String("xsd:double");
-    case QVariant::Time:
+    case QMetaType::QTime:
         return QLatin1String("xsd:time"); // correct? xmlpatterns fallsback to datetime because of missing timezone
-    case QVariant::Date:
+    case QMetaType::QDate:
         return QLatin1String("xsd:date");
-    case QVariant::DateTime:
+    case QMetaType::QDateTime:
         return QLatin1String("xsd:dateTime");
     default:
         if (value.userType() == qMetaTypeId<float>()) {

--- a/testtools/httpserver_p.cpp
+++ b/testtools/httpserver_p.cpp
@@ -46,7 +46,11 @@ static bool textBufferCompare(const QByteArray &source, const QByteArray &dest, 
 
 static void initHashSeed()
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
     qSetGlobalQHashSeed(0);
+#else
+    QHashSeed::setDeterministicGlobalSeed();
+#endif
 }
 
 Q_CONSTRUCTOR_FUNCTION(initHashSeed)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -97,6 +97,7 @@ add_subdirectory(ws_usernametoken_support)
 add_subdirectory(empty_element_wsdl)
 add_subdirectory(ws_discovery_wsdl)
 add_subdirectory(soap_over_udp)
+add_subdirectory(kdwsdl2cpp_jobs)
 
 # These need internet access
 add_subdirectory(webcalls)

--- a/unittests/kddatetime/test_kddatetime.cpp
+++ b/unittests/kddatetime/test_kddatetime.cpp
@@ -11,6 +11,7 @@
 #include "KDDateTime.h"
 #include "KDSoapValue.h"
 #include <QTest>
+#include <QTimeZone>
 
 class KDDateTimeTest : public QObject
 {
@@ -34,6 +35,63 @@ private Q_SLOTS:
 
         QCOMPARE(inputDateTime.timeZone(), outputDateTime.timeZone());
         QCOMPARE(inputDateTime.toDateString(), outputDateTime.toDateString());
+    }
+
+    void testSetTimeZone_data()
+    {
+        QTest::addColumn<QString>("timeZone");
+        QTest::addColumn<QString>("expected");
+
+        // Example countries and their offsets.
+
+        QTest::newRow("empty") << "" << QDateTime({2020, 1, 1}, {0, 0}, QTimeZone::systemTimeZone()).timeZoneAbbreviation();
+        QTest::newRow("Z") << "Z" << "UTC";
+        QTest::newRow("US Minor outlying islands") << "-12:00" << "UTC-12:00";
+        QTest::newRow("New Zealand (Niue)") << "-11:00" << "UTC-11:00";
+        QTest::newRow("Hawaii") << "-10:00" << "UTC-10:00";
+        QTest::newRow("Marquesas Islands (French Polynesia)") << "-09:30" << "UTC-09:30";
+        QTest::newRow("Alaska") << "-09:00" << "UTC-09:00";
+        QTest::newRow("US Pacific") << "-08:00" << "UTC-08:00";
+        QTest::newRow("US Mountain") << "-07:00" << "UTC-07:00";
+        QTest::newRow("US Central") << "-06:00" << "UTC-06:00";
+        QTest::newRow("US Eastern") << "-05:00" << "UTC-05:00";
+        QTest::newRow("US Atlantic") << "-04:00" << "UTC-04:00";
+        QTest::newRow("Canada Newfoundland") << "-03:30" << "UTC-03:30";
+        QTest::newRow("Argentina") << "-03:00" << "UTC-03:00";
+        QTest::newRow("Greenland") << "-02:00" << "UTC-02:00";
+        QTest::newRow("Cape Verde") << "-01:00" << "UTC-01:00";
+        QTest::newRow("United Kingdom 1") << "+00:00" << "UTC";
+        QTest::newRow("United Kingdom 2") << "-00:00" << "UTC";
+        QTest::newRow("France (Metropolitan)") << "+01:00" << "UTC+01:00";
+        QTest::newRow("Greece") << "+02:00" << "UTC+02:00";
+        QTest::newRow("Turkey") << "+03:00" << "UTC+03:00";
+        QTest::newRow("Iran") << "+03:30" << "UTC+03:30";
+        QTest::newRow("Seychelles") << "+04:00" << "UTC+04:00";
+        QTest::newRow("Afghanistan") << "+04:30" << "UTC+04:30";
+        QTest::newRow("Kazakhstan") << "+05:00" << "UTC+05:00";
+        QTest::newRow("India") << "+05:30" << "UTC+05:30";
+        QTest::newRow("Bhutan") << "+06:00" << "UTC+06:00";
+        QTest::newRow("Myanmar") << "+06:30" << "UTC+06:30";
+        QTest::newRow("Cambodia") << "+07:00" << "UTC+07:00";
+        QTest::newRow("Western Australia") << "+08:00" << "UTC+08:00";
+        QTest::newRow("Western Australia (Eucla)") << "+08:45" << "UTC+08:45";
+        QTest::newRow("Japan") << "+09:00" << "UTC+09:00";
+        QTest::newRow("Australia (Adelaide)") << "+09:30" << "UTC+09:30";
+        QTest::newRow("Australia (Sydney)") << "+10:00" << "UTC+10:00";
+        QTest::newRow("Australia (Lord Howe Island)") << "+10:30" << "UTC+10:30";
+        QTest::newRow("Australia (Norfolk Island)") << "+11:00" << "UTC+11:00";
+        QTest::newRow("New Zealand") << "+12:00" << "UTC+12:00";
+        QTest::newRow("New Zealand (Chatham Islands)") << "+12:45" << "UTC+12:45";
+        QTest::newRow("Samoa") << "+13:00" << "UTC+13:00";
+        QTest::newRow("Kiribati (Line Islands)") << "+14:00" << "UTC+14:00";
+    }
+
+    void testSetTimeZone()
+    {
+        QFETCH(QString, timeZone);
+        QFETCH(QString, expected);
+
+        QCOMPARE(KDDateTime::fromDateString("2020-01-01T00:00" + timeZone).timeZoneAbbreviation(), expected);
     }
 };
 

--- a/unittests/kdwsdl2cpp_jobs/CMakeLists.txt
+++ b/unittests/kdwsdl2cpp_jobs/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This file is part of the KD Soap project.
+#
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+set(kdwsdl2cpp_jobs_SRCS test_jobs.cpp)
+set(WSDL_FILES jobs.wsdl)
+add_unittest(${kdwsdl2cpp_jobs_SRCS})

--- a/unittests/kdwsdl2cpp_jobs/jobs.wsdl
+++ b/unittests/kdwsdl2cpp_jobs/jobs.wsdl
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                  xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+                  targetNamespace="http://example.com/example/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:example="http://example.com/example/">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/example/">
+      <xsd:element name="test">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="test" type="xsd:unsignedInt" default="30000"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="testResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="response" type="xsd:boolean" default="false" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="testIn">
+    <wsdl:part name="parameters" element="example:test" />
+  </wsdl:message>
+  <wsdl:message name="testOut">
+    <wsdl:part name="parameters" element="example:testResponse" />
+  </wsdl:message>
+
+  <wsdl:portType name="ExampleSoap">
+    <wsdl:operation name="testRequestResponse">
+      <wsdl:input message="example:testIn" />
+      <wsdl:output message="example:testOut" />
+    </wsdl:operation>
+    <wsdl:operation name="testOneWay">
+      <wsdl:input message="example:testIn" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="ExampleSoap" type="example:ExampleSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="testRequestResponse">
+      <soap12:operation soapAction="http://example.com/example/testrequestresponse" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="testOneWay">
+      <soap12:operation soapAction="http://example.com/example/testoneway" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="Example">
+    <wsdl:port name="ExampleSoap" binding="example:ExampleSoap">
+      <soap12:address location="http://localhost/test" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/unittests/kdwsdl2cpp_jobs/test_jobs.cpp
+++ b/unittests/kdwsdl2cpp_jobs/test_jobs.cpp
@@ -1,0 +1,43 @@
+/****************************************************************************
+**
+** This file is part of the KD Soap project.
+**
+** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+**
+** SPDX-License-Identifier: MIT
+**
+****************************************************************************/
+
+#include "KDSoapClientInterface.h"
+#include "KDSoapMessage.h"
+#include "KDSoapPendingCallWatcher.h"
+#include "KDSoapValue.h"
+#include "httpserver_p.h"
+#include "wsdl_jobs.h"
+#include <QDebug>
+#include <QEventLoop>
+#include <QTest>
+
+using namespace KDSoapUnitTestHelpers;
+
+class LiteralTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+    }
+
+    void testRequest()
+    {
+        // just a compile check
+        Example service;
+        TestRequestResponseJob requestResponse(&service);
+        TestOneWayJob oneWay(&service);
+    }
+};
+
+QTEST_MAIN(LiteralTest)
+
+#include "test_jobs.moc"

--- a/unittests/kdwsdl2cpp_jobs/test_jobs.cpp
+++ b/unittests/kdwsdl2cpp_jobs/test_jobs.cpp
@@ -2,23 +2,14 @@
 **
 ** This file is part of the KD Soap project.
 **
-** SPDX-FileCopyrightText: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+** SPDX-FileCopyrightText: 2025 Jonathan Brady <jtjbrady@users.noreply.github.com>
 **
 ** SPDX-License-Identifier: MIT
 **
 ****************************************************************************/
 
-#include "KDSoapClientInterface.h"
-#include "KDSoapMessage.h"
-#include "KDSoapPendingCallWatcher.h"
-#include "KDSoapValue.h"
-#include "httpserver_p.h"
 #include "wsdl_jobs.h"
-#include <QDebug>
-#include <QEventLoop>
 #include <QTest>
-
-using namespace KDSoapUnitTestHelpers;
 
 class LiteralTest : public QObject
 {

--- a/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
+++ b/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
@@ -12,6 +12,7 @@
 
 #include <QObject>
 #include <QTest>
+#include <QTimeZone>
 
 #include "KDSoapAuthentication.h"
 #include "KDSoapNamespaceManager.h"

--- a/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
+++ b/unittests/ws_usernametoken_support/test_wsusernametoken.cpp
@@ -38,7 +38,11 @@ private Q_SLOTS:
 
         // Override the nonce and timestamp to make the test output consistent.
         auth.setOverrideWSUsernameNonce(QByteArray::fromBase64("LKqI6G/AikKCQrN0zqZFlg=="));
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
         auth.setOverrideWSUsernameCreatedTime(QDateTime(QDate(2010, 9, 16), QTime(7, 50, 45), Qt::UTC)); // 2010-09-16T07:50:45Z
+#else
+        auth.setOverrideWSUsernameCreatedTime(QDateTime(QDate(2010, 9, 16), QTime(7, 50, 45), QTimeZone(QTimeZone::UTC))); // 2010-09-16T07:50:45Z
+#endif
 
         client.setAuthentication(auth);
 


### PR DESCRIPTION
Create classes for SOAP OneWayOperations, fixes #311

Additionally don't use deprecated Qt features - should be able to compile KDSoap with QT_DISABLE_DEPRECATED_BEFORE=0x060900 / QT_DISABLE_DEPRECATED_UP_TO=0x060900.
libkode still uses one deprecated function in  schema/parser.cpp