### PR TITLE
Use correct version for SOAP replies.

### DIFF
--- a/src/KDSoapServer/KDSoapServerObjectInterface.h
+++ b/src/KDSoapServer/KDSoapServerObjectInterface.h
@@ -12,6 +12,7 @@
 
 #include "KDSoapDelayedResponseHandle.h"
 #include "KDSoapServerGlobal.h"
+#include <KDSoapClient/KDSoapClientInterface.h>
 #include <KDSoapClient/KDSoapMessage.h>
 
 #include <QIODevice>
@@ -252,10 +253,24 @@ public:
      */
     void writeXML(const QByteArray &reply, bool isFault = false);
 
+    /**
+     * Copy the information from other to this.
+     * @param other KDSoapServerObjectInterface
+     * \since 2.3
+     */
+    void copyFrom(KDSoapServerObjectInterface *other);
+
+    /**
+     * Return the SOAP version of the incoming request.
+     * \since 2.3
+     */
+    KDSoap::SoapVersion requestVersion() const;
+
 private:
     friend class KDSoapServerSocket;
     void setServerSocket(KDSoapServerSocket *serverSocket); // only valid during processRequest()
     void setRequestHeaders(const KDSoapHeaders &headers, const QByteArray &soapAction);
+    void setRequestVersion(KDSoap::SoapVersion requestVersion);
     KDSoapHeaders responseHeaders() const;
     QString responseNamespace() const;
     void storeFaultAttributes(KDSoapMessage &message) const;

--- a/src/KDSoapServer/KDSoapServerSocket_p.h
+++ b/src/KDSoapServer/KDSoapServerSocket_p.h
@@ -17,6 +17,7 @@
 #include <QSslSocket>
 #endif
 
+#include <KDSoapClient/KDSoapClientInterface.h>
 #include <QMap>
 QT_BEGIN_NAMESPACE
 class QObject;
@@ -52,10 +53,10 @@ private:
     bool handleWsdlDownload();
     bool handleFileDownload(KDSoapServerObjectInterface *serverObjectInterface, const QString &path);
     void makeCall(KDSoapServerObjectInterface *serverObjectInterface, const KDSoapMessage &requestMsg, KDSoapMessage &replyMsg,
-                  const KDSoapHeaders &requestHeaders, const QByteArray &soapAction, const QString &path);
-    void handleError(KDSoapMessage &replyMsg, const char *errorCode, const QString &error);
+                  const KDSoapHeaders &requestHeaders, const QByteArray &soapAction, const QString &path, KDSoap::SoapVersion soapVersion);
+    void handleError(KDSoapMessage &replyMsg, const char *errorCode, const QString &error, KDSoap::SoapVersion soapVersion = KDSoap::SoapVersion::SOAP1_1);
     void setSocketEnabled(bool enabled);
-    void writeXML(const QByteArray &xmlResponse, bool isFault);
+    void writeXML(const QByteArray &xmlResponse, bool isFault, KDSoap::SoapVersion soapVersion);
     friend class KDSoapServerObjectInterface;
 
     KDSoapSocketList *m_owner;


### PR DESCRIPTION
I've been sitting on this patch for 9 years.

Essentially no matter the incoming version of the SOAP request to KDSoapServer, it always replies with a SOAP 1.1 message body.
This stores the incoming SOAP version to ensure the reply uses the correct SOAP version.

I'll look at doing some unit tests for it, although after nearly a decade I know it works.