### PR TITLE
Fix CI due to: framework 'AGL' not found (QTBUG-137687)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,10 @@ jobs:
           - os: macos-latest
             config:
               qt_version: "5.15"
+          # ld: framework 'AGL' not found (QTBUG-137687)
+          - os: macos-latest
+            config:
+              qt_version: "6.5.*"
 
     steps:
       - name: Install Qt with options and default aqtversion


### PR DESCRIPTION
latest macos doesn't ship AGL anymore.